### PR TITLE
Install Freeswitch packages

### DIFF
--- a/debian/resources/fusionpbx.sh
+++ b/debian/resources/fusionpbx.sh
@@ -4,7 +4,7 @@
 echo "Install FusionPBX"
 
 #install dependencies
-apt-get install -y --force-yes vim git dbus haveged
+apt-get install -y --force-yes vim git dbus haveged ssl-cert
 apt-get install -y --force-yes ghostscript libtiff5-dev libtiff-tools
 
 #get the source code

--- a/debian/resources/switch/package-release.sh
+++ b/debian/resources/switch/package-release.sh
@@ -10,8 +10,13 @@ else
         curl http://files.freeswitch.org/repo/deb/freeswitch-1.6/key.gpg | apt-key add -
 fi
 apt-get update
-apt-get install -y --force-yes freeswitch-meta-vanilla freeswitch-mod-json-cdr libyuv-dev gdb freeswitch-mod-xml-cdr freeswitch-mod-verto freeswitch-lang-fr freeswitch-mod-say-fr freeswitch-mod-callcenter
-apt-get install -y --force-yes freeswitch-mod-rtc freeswitch-mod-png freeswitch-mod-opus freeswitch-mod-b64 freeswitch-mod-distributor freeswitch-mod-esl freeswitch-mod-fifo freeswitch-mod-memcache freeswitch-mod-shout
+apt-get install -y --force-yes freeswitch-meta-bare freeswitch-conf-vanilla freeswitch-meta-codecs freeswitch-mod-console freeswitch-mod-logfile freeswitch-mod-distributor
+apt-get install -y --force-yes freeswitch-mod-enum freeswitch-mod-cdr-csv freeswitch-mod-event-socket freeswitch-mod-sofia freeswitch-mod-loopback freeswitch-mod-memcache
+apt-get install -y --force-yes freeswitch-mod-conference freeswitch-mod-db freeswitch-mod-dptools freeswitch-mod-expr freeswitch-mod-fifo libyuv-dev freeswitch-mod-httapi
+apt-get install -y --force-yes freeswitch-mod-hash freeswitch-mod-esl freeswitch-mod-esf freeswitch-mod-fsv freeswitch-mod-valet-parking freeswitch-mod-dialplan-xml gdb
+apt-get install -y --force-yes freeswitch-mod-sndfile freeswitch-mod-native-file freeswitch-mod-local-stream freeswitch-mod-tone-stream freeswitch-mod-lua freeswitch-mod-say-en
+apt-get install -y --force-yes freeswitch-mod-xml-cdr freeswitch-mod-verto freeswitch-mod-callcenter freeswitch-mod-rtc freeswitch-mod-png freeswitch-mod-json-cdr freeswitch-mod-shout
+
 
 #set the file permissions
 chown -R freeswitch:freeswitch /var/lib/freeswitch

--- a/debian/resources/switch/package-release.sh
+++ b/debian/resources/switch/package-release.sh
@@ -17,7 +17,6 @@ apt-get install -y --force-yes freeswitch-mod-hash freeswitch-mod-esl freeswitch
 apt-get install -y --force-yes freeswitch-mod-sndfile freeswitch-mod-native-file freeswitch-mod-local-stream freeswitch-mod-tone-stream freeswitch-mod-lua freeswitch-mod-say-en
 apt-get install -y --force-yes freeswitch-mod-xml-cdr freeswitch-mod-verto freeswitch-mod-callcenter freeswitch-mod-rtc freeswitch-mod-png freeswitch-mod-json-cdr freeswitch-mod-shout
 
-
 #set the file permissions
 chown -R freeswitch:freeswitch /var/lib/freeswitch
 chmod -R g+s /var/lib/freeswitch

--- a/debian/resources/switch/package-release.sh
+++ b/debian/resources/switch/package-release.sh
@@ -10,7 +10,7 @@ else
         curl http://files.freeswitch.org/repo/deb/freeswitch-1.6/key.gpg | apt-key add -
 fi
 apt-get update
-apt-get install -y --force-yes freeswitch-meta-vanilla freeswitch-mod-json-cdr libyuv-dev gdb freeswitch-mod-xml-cdr freeswitch-mod-verto freeswitch-lang-fr freeswitch-mod-say-fr 
+apt-get install -y --force-yes freeswitch-meta-vanilla freeswitch-mod-json-cdr libyuv-dev gdb freeswitch-mod-xml-cdr freeswitch-mod-verto freeswitch-lang-fr freeswitch-mod-say-fr freeswitch-mod-callcenter
 apt-get install -y --force-yes freeswitch-mod-rtc freeswitch-mod-png freeswitch-mod-opus freeswitch-mod-b64 freeswitch-mod-distributor freeswitch-mod-esl freeswitch-mod-fifo freeswitch-mod-memcache freeswitch-mod-shout
 
 #set the file permissions

--- a/debian/resources/switch/package-release.sh
+++ b/debian/resources/switch/package-release.sh
@@ -10,10 +10,10 @@ else
         curl http://files.freeswitch.org/repo/deb/freeswitch-1.6/key.gpg | apt-key add -
 fi
 apt-get update
-apt-get install -y --force-yes freeswitch-meta-bare freeswitch-conf-vanilla freeswitch-meta-codecs freeswitch-mod-console freeswitch-mod-logfile freeswitch-mod-distributor
+apt-get install -y --force-yes freeswitch-meta-bare freeswitch-conf-vanilla freeswitch-meta-codecs freeswitch-mod-console freeswitch-mod-logfile freeswitch-mod-distributor gdb
 apt-get install -y --force-yes freeswitch-mod-enum freeswitch-mod-cdr-csv freeswitch-mod-event-socket freeswitch-mod-sofia freeswitch-mod-loopback freeswitch-mod-memcache
 apt-get install -y --force-yes freeswitch-mod-conference freeswitch-mod-db freeswitch-mod-dptools freeswitch-mod-expr freeswitch-mod-fifo libyuv-dev freeswitch-mod-httapi
-apt-get install -y --force-yes freeswitch-mod-hash freeswitch-mod-esl freeswitch-mod-esf freeswitch-mod-fsv freeswitch-mod-valet-parking freeswitch-mod-dialplan-xml gdb
+apt-get install -y --force-yes freeswitch-mod-hash freeswitch-mod-esl freeswitch-mod-esf freeswitch-mod-fsv freeswitch-mod-valet-parking freeswitch-mod-dialplan-xml freeswitch-dbg
 apt-get install -y --force-yes freeswitch-mod-sndfile freeswitch-mod-native-file freeswitch-mod-local-stream freeswitch-mod-tone-stream freeswitch-mod-lua freeswitch-mod-say-en
 apt-get install -y --force-yes freeswitch-mod-xml-cdr freeswitch-mod-verto freeswitch-mod-callcenter freeswitch-mod-rtc freeswitch-mod-png freeswitch-mod-json-cdr freeswitch-mod-shout
 

--- a/debian/resources/switch/package-release.sh
+++ b/debian/resources/switch/package-release.sh
@@ -9,9 +9,9 @@ else
         echo "deb http://files.freeswitch.org/repo/deb/freeswitch-1.6/ jessie main" > /etc/apt/sources.list.d/freeswitch.list
         curl http://files.freeswitch.org/repo/deb/freeswitch-1.6/key.gpg | apt-key add -
 fi
-apt-get update && apt-get install -y --force-yes freeswitch-all freeswitch-all-dbg gdb
-#apt-get remove freeswitch-all freeswitch-all-dbg
-#rm /etc/apt/sources.list.d/freeswitch.list
+apt-get update
+apt-get install -y --force-yes freeswitch-meta-vanilla freeswitch-mod-json-cdr libyuv-dev gdb freeswitch-mod-xml-cdr freeswitch-mod-verto freeswitch-lang-fr freeswitch-mod-say-fr 
+apt-get install -y --force-yes freeswitch-mod-rtc freeswitch-mod-png freeswitch-mod-opus freeswitch-mod-b64 freeswitch-mod-distributor freeswitch-mod-esl freeswitch-mod-fifo freeswitch-mod-memcache freeswitch-mod-shout
 
 #set the file permissions
 chown -R freeswitch:freeswitch /var/lib/freeswitch

--- a/debian/resources/switch/package-release.sh
+++ b/debian/resources/switch/package-release.sh
@@ -11,11 +11,13 @@ else
 fi
 apt-get update
 apt-get install -y --force-yes freeswitch-meta-bare freeswitch-conf-vanilla freeswitch-meta-codecs freeswitch-mod-console freeswitch-mod-logfile freeswitch-mod-distributor gdb
-apt-get install -y --force-yes freeswitch-mod-enum freeswitch-mod-cdr-csv freeswitch-mod-event-socket freeswitch-mod-sofia freeswitch-mod-loopback freeswitch-mod-memcache
+apt-get install -y --force-yes freeswitch-mod-enum freeswitch-mod-cdr-csv freeswitch-mod-event-socket freeswitch-mod-sofia freeswitch-mod-sofia-dbg freeswitch-mod-loopback
 apt-get install -y --force-yes freeswitch-mod-conference freeswitch-mod-db freeswitch-mod-dptools freeswitch-mod-expr freeswitch-mod-fifo libyuv-dev freeswitch-mod-httapi
 apt-get install -y --force-yes freeswitch-mod-hash freeswitch-mod-esl freeswitch-mod-esf freeswitch-mod-fsv freeswitch-mod-valet-parking freeswitch-mod-dialplan-xml freeswitch-dbg
-apt-get install -y --force-yes freeswitch-mod-sndfile freeswitch-mod-native-file freeswitch-mod-local-stream freeswitch-mod-tone-stream freeswitch-mod-lua freeswitch-mod-say-en
+apt-get install -y --force-yes freeswitch-mod-sndfile freeswitch-mod-native-file freeswitch-mod-local-stream freeswitch-mod-tone-stream freeswitch-mod-lua freeswitch-meta-mod-say
 apt-get install -y --force-yes freeswitch-mod-xml-cdr freeswitch-mod-verto freeswitch-mod-callcenter freeswitch-mod-rtc freeswitch-mod-png freeswitch-mod-json-cdr freeswitch-mod-shout
+apt-get install -y --force-yes freeswitch-mod-skypopen freeswitch-mod-skypopen-dbg freeswitch-mod-sms freeswitch-mod-sms-dbg freeswitch-mod-cidlookup freeswitch-mod-memcache
+apt-get install -y --force-yes freeswitch-mod-imagick freeswitch-mod-tts-commandline freeswitch-mod-directory freeswitch-mod-flite
 
 #set the file permissions
 chown -R freeswitch:freeswitch /var/lib/freeswitch


### PR DESCRIPTION
The Freeswitch all package forces the installation of freeswitch-mod-voicemail and this module has a dependency to install a mailserver like Postfix otherwise Freeswitch will not install.  The installation of any mailserver can be a major security risk.  

Therefore I have made the changes to allow the required packages to be installed without the freeswitch-mod-voicemail since this is no required by FusionPBX as far as I am aware.

There are a few other optional packages that I have added.  I also included the ssl-cert dependency which provides the snakeoil cert.

Best Regards
Errol
