### PR TITLE
BugFix-Artifact in ls-remote

### DIFF
--- a/debian/resources/fusionpbx.sh
+++ b/debian/resources/fusionpbx.sh
@@ -18,7 +18,7 @@ if [ $USE_SYSTEM_MASTER = true ]; then
 	BRANCH=""
 else
 	FUSION_MAJOR=$(git ls-remote --heads https://github.com/fusionpbx/fusionpbx.git | cut -d/ -f 3 | grep -P '^\d+\.\d+' | sort | tail -n 1 | cut -d. -f1)
-	FUSION_MINOR=$(git ls-remote --tags https://github.com/fusionpbx/fusionpbx.git $FUSION_MAJOR.* | cut -d/ -f3 |  grep -P '^\d+\.\d+' | sort | tail -n 1 | cut -d. -f2)
+	FUSION_MINOR=$(git ls-remote --tags https://github.com/fusionpbx/fusionpbx.git | grep "$FUSION_MAJOR.*" | cut -d/ -f3 |  grep -P '^\d+\.\d+' | sort | tail -n 1 | cut -d. -f2)
 	FUSION_VERSION=$FUSION_MAJOR.$FUSION_MINOR
 	verbose "Using version $FUSION_VERSION"
 	BRANCH="-b $FUSION_VERSION"

--- a/debian/resources/switch/source-release.sh
+++ b/debian/resources/switch/source-release.sh
@@ -14,7 +14,7 @@ CWD=$(pwd)
 #git clone https://freeswitch.org/stash/scm/fs/freeswitch.git /usr/src/freeswitch
 #git clone -b v1.6 https://freeswitch.org/stash/scm/fs/freeswitch.git /usr/src/freeswitch
 SWITCH_MAJOR=$(git ls-remote --heads https://freeswitch.org/stash/scm/fs/freeswitch.git "v*" | cut -d/ -f 3 | grep -P '^v\d+\.\d+' | sort | tail -n 1| cut -dv -f2)
-SWITCH_MINOR=$(git ls-remote --tags https://freeswitch.org/stash/scm/fs/freeswitch.git v$SWITCH_MAJOR.* | cut -d/ -f3 | cut -dv -f2 | cut -d. -f3 | sort -n | tail -n1)
+SWITCH_MINOR=$(git ls-remote --tags https://freeswitch.org/stash/scm/fs/freeswitch.git | grep "v$SWITCH_MAJOR\.*" | cut -d/ -f3 | cut -dv -f2 | cut -d. -f3 | sort -n | tail -n1)
 SWITCH_VERSION=$SWITCH_MAJOR.$SWITCH_MINOR
 echo "Using version $SWITCH_VERSION"
 cd /usr/src


### PR DESCRIPTION
it seems ls-remote filtering isn't working right, switched to using
grep, although it means more data as all tags have to be downloaded and
piped to grep it provides a more consistent result (1.6.13 could not be
filtered to)