### PR TITLE
transition from php5* packages to php-7.0*

### DIFF
--- a/debian/install.sh
+++ b/debian/install.sh
@@ -154,7 +154,7 @@ server_address=$(hostname -I)
 
 #restart services
 systemctl daemon-reload
-systemctl restart php5-fpm
+systemctl restart php7.0-fpm
 systemctl restart nginx
 systemctl restart fail2ban
 

--- a/debian/resources/nginx.sh
+++ b/debian/resources/nginx.sh
@@ -10,7 +10,7 @@ cd "$(dirname "$0")"
 verbose "Installing the web server"
 
 #install dependencies
-apt-get install -y --force-yes nginx php5 php5-cli php5-fpm php5-pgsql php5-sqlite php5-odbc php5-curl php5-imap php5-mcrypt
+apt-get install -y nginx php php-cli php-fpm php-pgsql php-sqlite3 php-odbc php-curl php-imap php-mcrypt
 
 #enable fusionpbx nginx config
 cp nginx/fusionpbx /etc/nginx/sites-available/fusionpbx

--- a/debian/resources/nginx.sh
+++ b/debian/resources/nginx.sh
@@ -30,7 +30,7 @@ else
 fi
 
 #install dependencies
-apt-get install -y nginx php7.0 php7.0-cli php7.0-fpm php7.0-pgsql php7.0-sqlite3 php7.0-odbc php7.0-curl php7.0-imap php7.0-mcrypt
+apt-get install -y nginx php7.0 php7.0-cli php7.0-fpm php7.0-pgsql php7.0-sqlite3 php7.0-odbc php7.0-curl php7.0-imap php7.0-mcrypt php7.0-xml
 
 #enable fusionpbx nginx config
 cp nginx/fusionpbx /etc/nginx/sites-available/fusionpbx

--- a/debian/resources/nginx.sh
+++ b/debian/resources/nginx.sh
@@ -28,6 +28,7 @@ else
                 wget -O - https://www.dotdeb.org/dotdeb.gpg | apt-key add -
         fi
 fi
+apt-get update
 
 #install dependencies
 apt-get install -y nginx php7.0 php7.0-cli php7.0-fpm php7.0-pgsql php7.0-sqlite3 php7.0-odbc php7.0-curl php7.0-imap php7.0-mcrypt php7.0-xml

--- a/debian/resources/nginx.sh
+++ b/debian/resources/nginx.sh
@@ -9,8 +9,28 @@ cd "$(dirname "$0")"
 #send a message
 verbose "Installing the web server"
 
+arch=$(uname -m)
+real_os=$(lsb_release -is)
+codename=$(lsb_release -cs)
+if [ $real_os = 'Ubuntu' ]; then
+        #16.10.x - */yakkety/
+        #16.04.x - */xenial/
+        #14.04.x - */trusty/
+        if [ $codename = 'trusty' ]; then
+                LC_ALL=C.UTF-8 add-apt-repository -y ppa:ondrej/php
+        fi
+else
+        #9.x - */stretch/
+        #8.x - */jessie/
+        if [ $codename = 'jessie' ]; then
+                echo "deb http://packages.dotdeb.org $codename all" > /etc/apt/sources.list.d/dotdeb.list
+                echo "deb-src http://packages.dotdeb.org $codename all" >> /etc/apt/sources.list.d/dotdeb.list
+                wget -O - https://www.dotdeb.org/dotdeb.gpg | apt-key add -
+        fi
+fi
+
 #install dependencies
-apt-get install -y nginx php php-cli php-fpm php-pgsql php-sqlite3 php-odbc php-curl php-imap php-mcrypt
+apt-get install -y nginx php7.0 php7.0-cli php7.0-fpm php7.0-pgsql php7.0-sqlite3 php7.0-odbc php7.0-curl php7.0-imap php7.0-mcrypt
 
 #enable fusionpbx nginx config
 cp nginx/fusionpbx /etc/nginx/sites-available/fusionpbx

--- a/debian/resources/nginx/fusionpbx
+++ b/debian/resources/nginx/fusionpbx
@@ -14,7 +14,7 @@ server{
 	}
 
 	location ~ \.php$ {
-		fastcgi_pass unix:/var/run/php5-fpm.sock;
+		fastcgi_pass unix:/var/run/php/php7.0-fpm.sock;
 		#fastcgi_pass 127.0.0.1:9000;
 		fastcgi_index index.php;
 		include fastcgi_params;
@@ -95,7 +95,7 @@ server {
 	}
 
 	location ~ \.php$ {
-		fastcgi_pass unix:/var/run/php5-fpm.sock;
+		fastcgi_pass unix:/var/run/php/php7.0-fpm.sock;
 		#fastcgi_pass 127.0.0.1:9000;
 		fastcgi_index index.php;
 		include fastcgi_params;
@@ -181,7 +181,7 @@ server {
 	}
 
 	location ~ \.php$ {
-		fastcgi_pass unix:/var/run/php5-fpm.sock;
+		fastcgi_pass unix:/var/run/php/php7.0-fpm.sock;
 		#fastcgi_pass 127.0.0.1:9000;
 		fastcgi_index index.php;
 		include fastcgi_params;

--- a/debian/resources/php.sh
+++ b/debian/resources/php.sh
@@ -10,12 +10,12 @@ cd "$(dirname "$0")"
 verbose "Configuring PHP"
 
 #update config if source is being used
-sed 's#post_max_size = .*#post_max_size = 80M#g' -i /etc/php5/fpm/php.ini
-sed 's#upload_max_filesize = .*#upload_max_filesize = 80M#g' -i /etc/php5/fpm/php.ini
+sed 's#post_max_size = .*#post_max_size = 80M#g' -i /etc/php/7.0/fpm/php.ini
+sed 's#upload_max_filesize = .*#upload_max_filesize = 80M#g' -i /etc/php/7.0/fpm/php.ini
 
-#restart php5-fpm
+#restart php-fpm
 #systemd
-/bin/systemctl restart php5-fpm
+/bin/systemctl restart php7.0-fpm
 
 #init.d
-#/usr/sbin/service php5-fpm restart
+#/usr/sbin/service php7.0-fpm restart


### PR DESCRIPTION
test is passed with Ubuntu 16.04 amd64
needs to change apt sources to 
1) http://files.freeswitch.org/repo/ubuntu/freeswitch-1.6/dists/xenial/ - no packages here
2) http://files.freeswitch.org/repo/ubuntu-1604/freeswitch-unstable/dists/xenial/ - to be checked

``
apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 1FDDF413C2B201E5
``

``
$ gpg --keyserver keyserver.ubuntu.com --recv-keys 1FDDF413C2B201E5
``

gpg: requesting key C2B201E5 from hkp server keyserver.ubuntu.com
gpg: /root/.gnupg/trustdb.gpg: trustdb created
gpg: key C2B201E5: public key "Freeswitch Commercial Package Repo (https://repo.freeswitch.com) <wking@freeswitch.org>" imported
gpg: Total number processed: 1
gpg:               imported: 1  (RSA: 1)

``
$ gpg --verbose --verify /var/lib/apt/lists/files.freeswitch.org_repo_ubuntu_freeswitch-1.6_dists_xenial_InRelease
``

gpg: armor header: Hash: SHA1
gpg: armor header: Version: GnuPG v1.4.12 (GNU/Linux)
gpg: original file name=''
gpg: Signature made Fri 15 Apr 2016 08:33:33 PM +06 using RSA key ID C2B201E5
gpg: using PGP trust model
gpg: Good signature from "Freeswitch Commercial Package Repo (https://repo.freeswitch.com) <wking@freeswitch.org>"
gpg: WARNING: This key is not certified with a trusted signature!
gpg:          There is no indication that the signature belongs to the owner.
Primary key fingerprint: ACAD 6613 7D22 A8A4 69FB  B57F 1FDD F413 C2B2 01E5
gpg: textmode signature, digest algorithm SHA1
