### PR TITLE
Fix to issue #76 - Use php5 for some dists with new command-line switch

### DIFF
--- a/debian/install.sh
+++ b/debian/install.sh
@@ -157,7 +157,11 @@ server_address=$(hostname -I)
 
 #restart services
 systemctl daemon-reload
-systemctl restart php7.0-fpm
+if [ .$USE_PHP5_PACKAGE = .true ]; then
+        systemctl restart php5-fpm
+else
+        systemctl restart php7.0-fpm
+fi
 systemctl restart nginx
 systemctl restart fail2ban
 

--- a/debian/resources/arguments.sh
+++ b/debian/resources/arguments.sh
@@ -13,6 +13,7 @@ if [ -z "$CPU_CHECK" ]; then
 	export USE_SWITCH_SOURCE=false
 	export USE_SWITCH_PACKAGE_ALL=false
 	export USE_SWITCH_PACKAGE_UNOFFICIAL_ARM=false
+	export USE_PHP5_PACKAGE=false
 	export USE_SWITCH_MASTER=false
 	export USE_SYSTEM_MASTER=false
 	export CPU_CHECK=true
@@ -24,6 +25,8 @@ if [ -z "$CPU_CHECK" ]; then
 		--use-switch-package-all ) export USE_SWITCH_PACKAGE_ALL=true; shift ;;
 		--use-switch-master ) export USE_SWITCH_MASTER=true; shift ;;
 		--use-system-master ) export USE_SYSTEM_MASTER=true; shift ;;
+		--use-php5-package ) export USE_PHP5_PACKAGE=true; shift ;;
+		--use-switch-package-unofficial-arm ) export USE_SWITCH_PACKAGE_UNOFFICIAL_ARM=true; export USE_PHP5_PACKAGE=true; shift ;;
 		--no-cpu-check ) export CPU_CHECK=false; shift ;;
 		-h | --help ) HELP=true; shift ;;
 		-- ) shift; break ;;

--- a/debian/resources/arguments.sh
+++ b/debian/resources/arguments.sh
@@ -3,7 +3,7 @@
 #Process command line options only if we haven't been processed once
 if [ -z "$CPU_CHECK" ]; then
 	export script_name=`basename "$0"`
-	ARGS=$(getopt -n '$script_name' -o h -l help,use-switch-source,use-switch-package-all,use-switch-master,use-switch-package-unofficial-arm,use-system-master,no-cpu-check -- "$@")
+	ARGS=$(getopt -n '$script_name' -o h -l help,use-switch-source,use-switch-package-all,use-switch-master,use-switch-package-unofficial-arm,use-php5-package,use-system-master,no-cpu-check -- "$@")
 	
 	if [ $? -ne 0 ]; then
 		error "Failed parsing options."
@@ -35,7 +35,8 @@ if [ -z "$CPU_CHECK" ]; then
 		warning "Debian installer script"
 		warning "	--use-switch-source will use freeswitch from source rather than ${green}(default:packages)"
 		warning "	--use-switch-package-all if using packages use the meta-all package"
-		warning "	--use-switch-package-unofficial-arm if your system is arm and you are using packages, use the unofficial arm repo"
+		warning "	--use-switch-package-unofficial-arm if your system is arm and you are using packages, use the unofficial arm repo and force php5* packages"
+		warning "	--use-php5-package use php5* packages instead of ${green}(default:php7.0)"
 		warning "	--use-switch-master will use master branch/packages for the switch instead of ${green}(default:stable)"
 		warning "	--use-system-master will use master branch/packages for the system instead of ${green}(default:stable)"
 		warning "	--no-cpu-check disable the cpu check ${green}(default:check)"

--- a/debian/resources/nginx.sh
+++ b/debian/resources/nginx.sh
@@ -22,6 +22,7 @@ fi
 if [ .$USE_PHP5_PACKAGE = .true ]; then
         #don't add php7.0 repository
         verbose "Switching forcefully to php5* packages"
+        LC_ALL=C.UTF-8 add-apt-repository -y ppa:ondrej/php5-compat
 elif [ .$real_os = .'Ubuntu' ]; then
         #16.10.x - */yakkety/
         #16.04.x - */xenial/

--- a/debian/resources/nginx.sh
+++ b/debian/resources/nginx.sh
@@ -22,12 +22,15 @@ fi
 if [ .$USE_PHP5_PACKAGE = .true ]; then
         #don't add php7.0 repository
         verbose "Switching forcefully to php5* packages"
+        which add-apt-repository || apt-get install -y software-properties-common
+        LC_ALL=C.UTF-8 add-apt-repository -y ppa:ondrej/php
         LC_ALL=C.UTF-8 add-apt-repository -y ppa:ondrej/php5-compat
 elif [ .$real_os = .'Ubuntu' ]; then
         #16.10.x - */yakkety/
         #16.04.x - */xenial/
         #14.04.x - */trusty/
         if [ .$codename = .'trusty' ]; then
+                which add-apt-repository || apt-get install -y software-properties-common
                 LC_ALL=C.UTF-8 add-apt-repository -y ppa:ondrej/php
         fi
 else

--- a/debian/resources/nginx.sh
+++ b/debian/resources/nginx.sh
@@ -50,6 +50,12 @@ fi
 
 #enable fusionpbx nginx config
 cp nginx/fusionpbx /etc/nginx/sites-available/fusionpbx
+#prepare socket name
+if [ .$USE_PHP5_PACKAGE = .true ]; then
+        sed -i /etc/nginx/sites-available/fusionpbx -e 's#unix:.*;#unix:/var/run/php5-fpm.sock;#g'
+else
+        sed -i /etc/nginx/sites-available/fusionpbx -e 's#unix:.*;#unix:/var/run/php/php7.0-fpm.sock;#g'
+fi
 ln -s /etc/nginx/sites-available/fusionpbx /etc/nginx/sites-enabled/fusionpbx
 
 #self signed certificate

--- a/debian/resources/nginx.sh
+++ b/debian/resources/nginx.sh
@@ -12,17 +12,27 @@ verbose "Installing the web server"
 arch=$(uname -m)
 real_os=$(lsb_release -is)
 codename=$(lsb_release -cs)
-if [ $real_os = 'Ubuntu' ]; then
+if [ .$USE_SWITCH_PACKAGE_UNOFFICIAL_ARM = .true ]; then
+        #9.x - */stretch/
+        #8.x - */jessie/
+        if [ .$codename = .'jessie' ]; then
+                USE_PHP5_PACKAGE = true
+        fi
+fi
+if [ .$USE_PHP5_PACKAGE = .true ]; then
+        #don't add php7.0 repository
+        verbose "Switching forcefully to php5* packages"
+elif [ .$real_os = .'Ubuntu' ]; then
         #16.10.x - */yakkety/
         #16.04.x - */xenial/
         #14.04.x - */trusty/
-        if [ $codename = 'trusty' ]; then
+        if [ .$codename = .'trusty' ]; then
                 LC_ALL=C.UTF-8 add-apt-repository -y ppa:ondrej/php
         fi
 else
         #9.x - */stretch/
         #8.x - */jessie/
-        if [ $codename = 'jessie' ]; then
+        if [ .$codename = .'jessie' ]; then
                 echo "deb http://packages.dotdeb.org $codename all" > /etc/apt/sources.list.d/dotdeb.list
                 echo "deb-src http://packages.dotdeb.org $codename all" >> /etc/apt/sources.list.d/dotdeb.list
                 wget -O - https://www.dotdeb.org/dotdeb.gpg | apt-key add -
@@ -31,7 +41,12 @@ fi
 apt-get update
 
 #install dependencies
-apt-get install -y nginx php7.0 php7.0-cli php7.0-fpm php7.0-pgsql php7.0-sqlite3 php7.0-odbc php7.0-curl php7.0-imap php7.0-mcrypt php7.0-xml
+apt-get install -y nginx
+if [ .$USE_PHP5_PACKAGE = .true ]; then
+        apt-get install -y php5 php5-cli php5-fpm php5-pgsql php5-sqlite php5-odbc php5-curl php5-imap php5-mcrypt
+else
+        apt-get install -y php7.0 php7.0-cli php7.0-fpm php7.0-pgsql php7.0-sqlite3 php7.0-odbc php7.0-curl php7.0-imap php7.0-mcrypt php7.0-xml
+fi
 
 #enable fusionpbx nginx config
 cp nginx/fusionpbx /etc/nginx/sites-available/fusionpbx

--- a/debian/resources/php.sh
+++ b/debian/resources/php.sh
@@ -10,12 +10,23 @@ cd "$(dirname "$0")"
 verbose "Configuring PHP"
 
 #update config if source is being used
-sed 's#post_max_size = .*#post_max_size = 80M#g' -i /etc/php/7.0/fpm/php.ini
-sed 's#upload_max_filesize = .*#upload_max_filesize = 80M#g' -i /etc/php/7.0/fpm/php.ini
+if [ .$USE_PHP5_PACKAGE = .true ]; then
+        verbose "version 5.x"
+        php_ini_file='/etc/php5/fpm/php.ini'
+else
+        verbose "version 7.0"
+        php_ini_file='/etc/php/7.0/fpm/php.ini'
+fi
+sed 's#post_max_size = .*#post_max_size = 80M#g' -i $php_ini_file
+sed 's#upload_max_filesize = .*#upload_max_filesize = 80M#g' -i $php_ini_file
 
 #restart php-fpm
 #systemd
-/bin/systemctl restart php7.0-fpm
+if [ .$USE_PHP5_PACKAGE = .true ]; then
+        systemctl restart php5-fpm
+else
+        systemctl restart php7.0-fpm
+fi
 
 #init.d
 #/usr/sbin/service php7.0-fpm restart


### PR DESCRIPTION
Example usage
``
./install.sh --use-php5-package
``
