### PR TITLE
BugFix core/upgrade/install.php timeout

### DIFF
--- a/centos/resources/nginx/fusionpbx
+++ b/centos/resources/nginx/fusionpbx
@@ -21,6 +21,16 @@ server{
 		fastcgi_param   SCRIPT_FILENAME /var/www/fusionpbx$fastcgi_script_name;
 	}
 
+	# Allow the upgrade routines to run longer than normal
+	location = /core/upgrade/index.php {
+		fastcgi_pass unix:/var/run/php/php-fpm.sock;
+		#fastcgi_pass 127.0.0.1:9000;
+		fastcgi_index index.php;
+		include fastcgi_params;
+		fastcgi_param   SCRIPT_FILENAME /var/www/fusionpbx$fastcgi_script_name;
+		fastcgi_read_timeout 15m;
+	}
+
 	# Disable viewing .htaccess & .htpassword & .db
 	location ~ .htaccess {
 			deny all;
@@ -102,6 +112,16 @@ server {
 		fastcgi_param   SCRIPT_FILENAME /var/www/fusionpbx$fastcgi_script_name;
 	}
 
+	# Allow the upgrade routines to run longer than normal
+	location = /core/upgrade/index.php {
+		fastcgi_pass unix:/var/run/php/php-fpm.sock;
+		#fastcgi_pass 127.0.0.1:9000;
+		fastcgi_index index.php;
+		include fastcgi_params;
+		fastcgi_param   SCRIPT_FILENAME /var/www/fusionpbx$fastcgi_script_name;
+		fastcgi_read_timeout 15m;
+	}
+
 	# Disable viewing .htaccess & .htpassword & .db
 	location ~ .htaccess {
 		deny all;
@@ -181,6 +201,16 @@ server {
 		fastcgi_index index.php;
 		include fastcgi_params;
 		fastcgi_param   SCRIPT_FILENAME /var/www/fusionpbx$fastcgi_script_name;
+	}
+
+	# Allow the upgrade routines to run longer than normal
+	location = /core/upgrade/index.php {
+		fastcgi_pass unix:/var/run/php/php-fpm.sock;
+		#fastcgi_pass 127.0.0.1:9000;
+		fastcgi_index index.php;
+		include fastcgi_params;
+		fastcgi_param   SCRIPT_FILENAME /var/www/fusionpbx$fastcgi_script_name;
+		fastcgi_read_timeout 15m;
 	}
 
 	# Disable viewing .htaccess & .htpassword & .db

--- a/debian/resources/nginx/fusionpbx
+++ b/debian/resources/nginx/fusionpbx
@@ -21,6 +21,16 @@ server{
 		fastcgi_param   SCRIPT_FILENAME /var/www/fusionpbx$fastcgi_script_name;
 	}
 
+	# Allow the upgrade routines to run longer than normal
+	location = /core/upgrade/index.php {
+		fastcgi_pass unix:/var/run/php/php7.0-fpm.sock;
+		#fastcgi_pass 127.0.0.1:9000;
+		fastcgi_index index.php;
+		include fastcgi_params;
+		fastcgi_param   SCRIPT_FILENAME /var/www/fusionpbx$fastcgi_script_name;
+		fastcgi_read_timeout 15m;
+	}
+
 	# Disable viewing .htaccess & .htpassword & .db
 	location ~ .htaccess {
 			deny all;
@@ -100,6 +110,16 @@ server {
 		fastcgi_index index.php;
 		include fastcgi_params;
 		fastcgi_param   SCRIPT_FILENAME /var/www/fusionpbx$fastcgi_script_name;
+	}
+
+	# Allow the upgrade routines to run longer than normal
+	location = /core/upgrade/index.php {
+		fastcgi_pass unix:/var/run/php/php7.0-fpm.sock;
+		#fastcgi_pass 127.0.0.1:9000;
+		fastcgi_index index.php;
+		include fastcgi_params;
+		fastcgi_param   SCRIPT_FILENAME /var/www/fusionpbx$fastcgi_script_name;
+		fastcgi_read_timeout 15m;
 	}
 
 	# Disable viewing .htaccess & .htpassword & .db
@@ -186,6 +206,16 @@ server {
 		fastcgi_index index.php;
 		include fastcgi_params;
 		fastcgi_param   SCRIPT_FILENAME /var/www/fusionpbx$fastcgi_script_name;
+	}
+
+	# Allow the upgrade routines to run longer than normal
+	location = /core/upgrade/index.php {
+		fastcgi_pass unix:/var/run/php/php7.0-fpm.sock;
+		#fastcgi_pass 127.0.0.1:9000;
+		fastcgi_index index.php;
+		include fastcgi_params;
+		fastcgi_param   SCRIPT_FILENAME /var/www/fusionpbx$fastcgi_script_name;
+		fastcgi_read_timeout 15m;
 	}
 
 	# Disable viewing .htaccess & .htpassword & .db

--- a/devuan/resources/nginx/fusionpbx
+++ b/devuan/resources/nginx/fusionpbx
@@ -21,6 +21,16 @@ server{
 		fastcgi_param   SCRIPT_FILENAME /var/www/fusionpbx$fastcgi_script_name;
 	}
 
+	# Allow the upgrade routines to run longer than normal
+	location = /core/upgrade/index.php {
+		fastcgi_pass unix:/var/run/php/php7.0-fpm.sock;
+		#fastcgi_pass 127.0.0.1:9000;
+		fastcgi_index index.php;
+		include fastcgi_params;
+		fastcgi_param   SCRIPT_FILENAME /var/www/fusionpbx$fastcgi_script_name;
+		fastcgi_read_timeout 15m;
+	}
+
 	# Disable viewing .htaccess & .htpassword & .db
 	location ~ .htaccess {
 			deny all;
@@ -102,6 +112,16 @@ server {
 		fastcgi_param   SCRIPT_FILENAME /var/www/fusionpbx$fastcgi_script_name;
 	}
 
+	# Allow the upgrade routines to run longer than normal
+	location = /core/upgrade/index.php {
+		fastcgi_pass unix:/var/run/php/php7.0-fpm.sock;
+		#fastcgi_pass 127.0.0.1:9000;
+		fastcgi_index index.php;
+		include fastcgi_params;
+		fastcgi_param   SCRIPT_FILENAME /var/www/fusionpbx$fastcgi_script_name;
+		fastcgi_read_timeout 15m;
+	}
+
 	# Disable viewing .htaccess & .htpassword & .db
 	location ~ .htaccess {
 		deny all;
@@ -178,6 +198,16 @@ server {
 	location / {
 		root /var/www/fusionpbx;
 		index index.php;
+	}
+
+	# Allow the upgrade routines to run longer than normal
+	location = /core/upgrade/index.php {
+		fastcgi_pass unix:/var/run/php/php7.0-fpm.sock;
+		#fastcgi_pass 127.0.0.1:9000;
+		fastcgi_index index.php;
+		include fastcgi_params;
+		fastcgi_param   SCRIPT_FILENAME /var/www/fusionpbx$fastcgi_script_name;
+		fastcgi_read_timeout 15m;
 	}
 
 	location ~ \.php$ {

--- a/freebsd/resources/fusionpbx/fusionpbx
+++ b/freebsd/resources/fusionpbx/fusionpbx
@@ -21,6 +21,16 @@ server{
 		fastcgi_param   SCRIPT_FILENAME /var/www/fusionpbx$fastcgi_script_name;
 	}
 
+	# Allow the upgrade routines to run longer than normal
+	location = /core/upgrade/index.php {
+		fastcgi_pass unix:/var/run/php/php7.0-fpm.sock;
+		#fastcgi_pass 127.0.0.1:9000;
+		fastcgi_index index.php;
+		include fastcgi_params;
+		fastcgi_param   SCRIPT_FILENAME /var/www/fusionpbx$fastcgi_script_name;
+		fastcgi_read_timeout 15m;
+	}
+
 	# Disable viewing .htaccess & .htpassword & .db
 	location ~ .htaccess {
 			deny all;
@@ -92,6 +102,16 @@ server {
 	location / {
 		root /var/www/fusionpbx;
 		index index.php;
+	}
+
+	# Allow the upgrade routines to run longer than normal
+	location = /core/upgrade/index.php {
+		fastcgi_pass unix:/var/run/php/php7.0-fpm.sock;
+		#fastcgi_pass 127.0.0.1:9000;
+		fastcgi_index index.php;
+		include fastcgi_params;
+		fastcgi_param   SCRIPT_FILENAME /var/www/fusionpbx$fastcgi_script_name;
+		fastcgi_read_timeout 15m;
 	}
 
 	location ~ \.php$ {
@@ -186,6 +206,16 @@ server {
 		fastcgi_index index.php;
 		include fastcgi_params;
 		fastcgi_param   SCRIPT_FILENAME /var/www/fusionpbx$fastcgi_script_name;
+	}
+
+	# Allow the upgrade routines to run longer than normal
+	location = /core/upgrade/index.php {
+		fastcgi_pass unix:/var/run/php/php7.0-fpm.sock;
+		#fastcgi_pass 127.0.0.1:9000;
+		fastcgi_index index.php;
+		include fastcgi_params;
+		fastcgi_param   SCRIPT_FILENAME /var/www/fusionpbx$fastcgi_script_name;
+		fastcgi_read_timeout 15m;
 	}
 
 	# Disable viewing .htaccess & .htpassword & .db


### PR DESCRIPTION
update configuration to allow the core/upgrade/install.php to have the
same read_timeout in nginx as it has in php execution time.
This should prevent the nginx timeout error when a upgrade takes longer
than 60 seconds (the deafult in nginx)