### PR TITLE
Added minimal OpenVZ support.

### DIFF
--- a/debian/resources/switch/package-systemd.sh
+++ b/debian/resources/switch/package-systemd.sh
@@ -2,6 +2,11 @@ apt-get remove -y --force-yes freeswitch-systemd
 cp "$(dirname $0)/source/freeswitch.service.package" /lib/systemd/system/freeswitch.service
 cp "$(dirname $0)/source/etc.default.freeswitch.package" /etc/default/freeswitch
 chmod 644 /lib/systemd/system/freeswitch.service 
+if [ -e /proc/user_beancounters ]
+then
+    echo "Oh, your on OpenVZ! Setting a CPU Scheduler isn't possible :("
+    sed -i -e "s/CPUSchedulingPolicy=rr/;CPUSchedulingPolicy=rr/g" /lib/systemd/system/freeswitch.service
+fi
 systemctl enable freeswitch
 systemctl unmask freeswitch.service
 systemctl daemon-reload

--- a/debian/resources/switch/source-systemd.sh
+++ b/debian/resources/switch/source-systemd.sh
@@ -1,5 +1,10 @@
 cp "$(dirname $0)/source/freeswitch.service.source" /lib/systemd/system/freeswitch.service
 cp "$(dirname $0)/source/etc.default.freeswitch.source" /etc/default/freeswitch
+if [ -e /proc/user_beancounters ]
+then
+    echo "Oh, your on OpenVZ! Setting a CPU Scheduler isn't possible :("
+    sed -i -e "s/CPUSchedulingPolicy=rr/;CPUSchedulingPolicy=rr/g" /lib/systemd/system/freeswitch.service
+fi
 systemctl enable freeswitch
 systemctl unmask freeswitch.service
 systemctl daemon-reload


### PR DESCRIPTION
This will get Freeswitch working on OpenVZ containers, but FusionPBX still isn't properly set up due to a few OpenVZ quirks causing issues with these scripts. May want to use these changes on other distros too, namely CentOS.