### PR TITLE
Handle bad IP addresses properly, avoid making localhost into the default domain.

### DIFF
--- a/debian/install.sh
+++ b/debian/install.sh
@@ -42,9 +42,6 @@ resources/switch.sh
 #Postgres
 resources/postgres.sh
 
-#set the ip address
-server_address=$(hostname -I)
-
 #restart services
 systemctl daemon-reload
 if [ ."$php_version" = ."5" ]; then

--- a/debian/resources/finish.sh
+++ b/debian/resources/finish.sh
@@ -39,6 +39,12 @@ cd /var/www/fusionpbx && php /var/www/fusionpbx/core/upgrade/upgrade_schema.php 
 #get the ip address
 domain_name=$(hostname -I | cut -d ' ' -f1)
 
+#check if loopback address was found (OpenVZ issue)
+if [[ $domain_name == "127."* ]]; then
+    echo "What should we call your main domain? (An IP address also works!)"
+    read domain_name
+fi
+
 #get a domain_uuid
 domain_uuid=$(/usr/bin/php /var/www/fusionpbx/resources/uuid.php);
 


### PR DESCRIPTION
Here is another issue I've commonly seen on OpenVZ, hostname -I will return something like: 

> 127.0.0.2 172.43.0.15 2600:520::8::0 

Which eventually ends up with 127.0.0.2 set as the default domain. I get that its odd that venet0 (the default network interface on OpenVZ) usually has 127.0.0.2 assigned to it, alongside a public IPv6, with venet0:0 holding the true IPv4, but this is pretty straightforward to handle.

It might actually be a better tact to always prompt for users to input a domain or IP, if a domain is input we could trigger TLS cert creation and load that cert into Nginx and FreeSWITCH.