### PR TITLE
Easy disabling of LetsEncrypt folders

### DIFF
--- a/debian/resources/config.sh
+++ b/debian/resources/config.sh
@@ -17,3 +17,4 @@ database_backup=false           # true or false
 
 # General Settings
 php_version=5                   # PHP version 5 or 7
+letsencrypt_folder=true        # true or false

--- a/debian/resources/nginx.sh
+++ b/debian/resources/nginx.sh
@@ -34,7 +34,7 @@ elif [ ."$cpu_architecture" = ."arm" ]; then
         if [ ."$os_codename" = ."jessie" ]; then
                 echo "deb http://packages.moopi.uk/debian jessie main" > /etc/apt/sources.list.d/moopi.list
                 wget -O - http://packages.moopi.uk/debian/moopi.gpg.key | apt-key add -
-        fi        
+        fi
 else
         #9.x - */stretch/
         #8.x - */jessie/
@@ -79,8 +79,15 @@ ln -s /etc/ssl/certs/ssl-cert-snakeoil.pem /etc/ssl/certs/nginx.crt
 #remove the default site
 rm /etc/nginx/sites-enabled/default
 
+#update config if LetsEncrypt folder is unwanted
+if [ .$letsencrypt_folder = .false ]; then
+        sed -i '151,155d' /etc/nginx/sites-available/fusionpbx
+fi
+
 #add the letsencrypt directory
-mkdir -p /var/www/letsencrypt/
+if [ .$letsencrypt_folder = .true ]; then
+        mkdir -p /var/www/letsencrypt/
+fi
 
 #restart nginx
 service nginx restart


### PR DESCRIPTION
I kept stubbing my toe on this when using acme.sh, figured making it switchable might be a good idea. Might add acme.sh support if there is any interest.