### PR TITLE
Ban on auth failure instead of challenge

### DIFF
--- a/debian/resources/fail2ban/freeswitch-dos.conf
+++ b/debian/resources/fail2ban/freeswitch-dos.conf
@@ -12,7 +12,7 @@
 #          (?:::f{4,6}:)?(?P<host>[\w\-.^_]+)
 # Values:  TEXT
 #
-failregex = \[WARNING\] sofia_reg.c:\d+ SIP auth challenge \(REGISTER\) on sofia profile \'\w+\' for \[.*\] from ip <HOST>
+failregex = \[WARNING\] sofia_reg.c:\d+ SIP auth failure \(REGISTER\) on sofia profile \'\w+\' for \[.*\] from ip <HOST>
 
 # Option:  ignoreregex
 # Notes.:  regex to ignore. If this regex matches, the line is ignored.


### PR DESCRIPTION
Default fail2ban DoS ruleset looks for auth challenges, but auth challenges can be either successful or unsuccessful. Default rule causes problems with larger environments with many registered devices as they have many successful auth challenges with short registration periods.

By the time auth challenges can be made successfully in volume, it's far too late to be worrying about a DoS or brute force attempt. Rule change here will reduce false positives while still providing same level of useful protection.

Maybe also consider reducing maxretry count or increasing findtime in jail.local to catch true failed auth brute force or DoS attempts more easily in conjunction with above change.

This will be more sensitive in detection and should carry lower false positive rate.