### PR TITLE
Changed Fail2ban settings, updated Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
 
 FusionPBX Install
 --------------------------------------
-A quick install guide for a FusionPBX install. It is recommended to start the install on a minimal install of the operating system.
+A quick install guide for a FusionPBX install. It is recommended to start the install on a minimal install of the operating system. Notes on further tweaking your configuration are at end of the file.
 
-
+## Operating Systems
 ### Debian
 Debian 8 is the preferred operating system by the FreeSWITCH developers. It supports the latest video dependencies. If you want to do video mixing use Debian. Download Debian 8 Jessie from here https://cdimage.debian.org/cdimage/archive/
 
@@ -13,7 +13,7 @@ cd /usr/src/fusionpbx-install.sh/debian && ./install.sh
 ```
 ### Devuan
 If you like Debian but rather not bother with systemd, Devuan is a "drop in" replacement.
-Version 1 is bassed on Jessie. So you will find the same packages available.
+Version 1 is bassed on Jessie, so you will find the same packages available.
 Please note that the source installation and installation on ARM is not fully tested.
 
 ```sh
@@ -45,10 +45,13 @@ cd /usr/src/fusionpbx-install.sh/centos && ./install.sh
 *  Click to download the zip file and extract it.
 *  Extract the zip file
 *  Navigate to install.ps1
-*  Click on install.ps1 then right click on install.ps1 then choose Run with Powershell 
+*  Click on install.ps1 then right click on install.ps1 then choose Run with Powershell
 *  If you are not already Administrator you will have to choose run as Administrator
 
 ```sh
 
 Master https://github.com/fusionpbx/fusionpbx-install.sh/archive/master.zip
 ```
+
+## Security Considerations
+Fail2ban is installed and pre-configured for all operating systems this repository works on besides Windows, but the default settings may not be ideal depending on your needs. Please take a look at the jail file (/etc/fail2ban/jail.local on Debian/Devuan) to configure it to suit your application and security model!

--- a/centos/resources/fail2ban/jail.local
+++ b/centos/resources/fail2ban/jail.local
@@ -95,7 +95,7 @@ port     = 80,443
 protocol = tcp
 filter   = nginx-404
 logpath  = /var/log/nginx/access*.log
-bantime  = 600
+bantime  = 3600
 findtime = 60
 maxretry = 120
 

--- a/centos/resources/fail2ban/jail.local
+++ b/centos/resources/fail2ban/jail.local
@@ -103,11 +103,11 @@ maxretry = 120
 # Based on apache-badbots but a simple IP check (any IP requesting more than
 # 240 pages in 60 seconds, or 4p/s average, is suspicious)
 # Block for two full days.
-enabled  = true
+enabled  = false
 port     = 80,443
 protocol = tcp
 filter   = nginx-dos
 logpath  = /var/log/nginx/access*.log
 findtime = 60
-bantime  = 172800
+bantime  = 86400
 maxretry = 240

--- a/debian/resources/fail2ban/jail.local
+++ b/debian/resources/fail2ban/jail.local
@@ -113,7 +113,7 @@ protocol = tcp
 filter   = nginx-404
 logpath  = /var/log/nginx/access*.log
 action   = iptables-allports[name=nginx-404, protocol=all]
-bantime  = 600
+bantime  = 3600
 findtime = 60
 maxretry = 120
 

--- a/debian/resources/fail2ban/jail.local
+++ b/debian/resources/fail2ban/jail.local
@@ -104,7 +104,7 @@ action   = iptables-allports[name=fusionpbx-mac, protocol=all]
 #          sendmail-whois[name=fusionpbx-mac, dest=root, sender=fail2ban@example.org] #no smtp server installed
 maxretry = 5
 findtime = 300
-bantime  = -1
+bantime  = 86400
 
 [nginx-404]
 enabled  = true
@@ -113,19 +113,19 @@ protocol = tcp
 filter   = nginx-404
 logpath  = /var/log/nginx/access*.log
 action   = iptables-allports[name=nginx-404, protocol=all]
-bantime  = 3600
+bantime  = 600
 findtime = 60
 maxretry = 120
 
 [nginx-dos]
 # Based on apache-badbots but a simple IP check (any IP requesting more than
 # 240 pages in 60 seconds, or 4p/s average, is suspicious)
-enabled  = true
+enabled  = false
 port     = 80,443
 protocol = tcp
 filter   = nginx-dos
 logpath  = /var/log/nginx/access*.log
 action   = iptables-allports[name=nginx-dos, protocol=all]
 findtime = 60
-bantime  = -1
+bantime  = 86400
 maxretry = 240

--- a/devuan/resources/fail2ban/jail.local
+++ b/devuan/resources/fail2ban/jail.local
@@ -95,7 +95,7 @@ port     = 80,443
 protocol = tcp
 filter   = nginx-404
 logpath  = /var/log/nginx/access*.log
-bantime  = 600
+bantime  = 3600
 findtime = 60
 maxretry = 120
 

--- a/devuan/resources/fail2ban/jail.local
+++ b/devuan/resources/fail2ban/jail.local
@@ -103,11 +103,11 @@ maxretry = 120
 # Based on apache-badbots but a simple IP check (any IP requesting more than
 # 240 pages in 60 seconds, or 4p/s average, is suspicious)
 # Block for two full days.
-enabled  = true
+enabled  = false
 port     = 80,443
 protocol = tcp
 filter   = nginx-dos
 logpath  = /var/log/nginx/access*.log
 findtime = 60
-bantime  = 172800
+bantime  = 86400
 maxretry = 240

--- a/freebsd/resources/fail2ban/jail.local
+++ b/freebsd/resources/fail2ban/jail.local
@@ -80,7 +80,7 @@ logpath  = /var/log/nginx/access*.log
 findtime = 60
 maxretry = 120
 banaction = pf
-bantime  = 600
+bantime  = 3600
 
 [nginx-dos]
 # Based on apache-badbots but a simple IP check (any IP requesting more than

--- a/freebsd/resources/fail2ban/jail.local
+++ b/freebsd/resources/fail2ban/jail.local
@@ -80,13 +80,13 @@ logpath  = /var/log/nginx/access*.log
 findtime = 60
 maxretry = 120
 banaction = pf
-bantime  = 3600
+bantime  = 600
 
 [nginx-dos]
 # Based on apache-badbots but a simple IP check (any IP requesting more than
 # 240 pages in 60 seconds, or 4p/s average, is suspicious)
 # Block for two full days.
-enabled  = true
+enabled  = false
 port     = 80,443
 protocol = tcp
 filter   = nginx-dos
@@ -94,4 +94,4 @@ logpath  = /var/log/nginx/access*.log
 findtime = 60
 maxretry = 240
 banaction = pf
-bantime  = 172800
+bantime  = 86400


### PR DESCRIPTION
Nginx-dos was triggered by auto-refresh behavior in FusionPBX when on certain pages like Active Calls, this permanent ban was easy to hit if Active Calls was open in more than 1 tab/window. This pull request disables this rule by default, and makes its ban time consistent across OSes that have Fail2ban installed when running the scripts from this repository.

