### PR TITLE
Bugfix: Fix  the user/group  for /etc/php-fpm.d/www.conf

### DIFF
--- a/centos/resources/php.sh
+++ b/centos/resources/php.sh
@@ -28,8 +28,8 @@ TIMEZ=$(timedatectl | grep 'Time zone' | awk '{ print $3 }')
 sed -ie "s#;date.timezone =#date.timezone = $TIMEZ#g" /etc/php.ini
 sed -ie 's/;cgi.fix_pathinfo=1/cgi.fix_pathinfo=0/g' /etc/php.ini
 sed -ie "s|listen = 127.0.0.1:9000|listen = /var/run/php-fpm/php-fpm.sock|g" /etc/php-fpm.d/www.conf
-sed -ie 's/;listen.owner = nobody/listen.owner = nobody/g' /etc/php-fpm.d/www.conf
-sed -ie 's/;listen.group = nobody/listen.group = nobody/g' /etc/php-fpm.d/www.conf
+sed -ie 's/;listen.owner = nobody/listen.owner = freeswitch/g' /etc/php-fpm.d/www.conf
+sed -ie 's/;listen.group = nobody/listen.group = daemon/g' /etc/php-fpm.d/www.conf
 sed -ie 's/group = apache/group = daemon/g' /etc/php-fpm.d/www.conf
 
 #update the php.ini


### PR DESCRIPTION
For a clean install of Centos 7 and using the installer php-fpm get the
permission error

"unix:/var/run/php-fpm/php-fpm.sock failed (13: Permission denied) while
connecting to upstream"

This patch the correct group and user to run php-fpm process.