### PR TITLE
Update sed entries in debian/letsencrypt.sh file

### DIFF
--- a/debian/resources/letsencrypt.sh
+++ b/debian/resources/letsencrypt.sh
@@ -58,8 +58,8 @@ cp docs/examples/config /etc/dehydrated
 
 #update the dehydrated config
 #sed "s#CONTACT_EMAIL=#CONTACT_EMAIL=$email_address" -i /etc/dehydrated/config
-sed -i' ' -e s:'#CONTACT_EMAIL=":CONTACT_EMAIL=$email_address:' /etc/dehydrated/config
-sed -i' ' -e s:'#WELLKNOWN="/var/www/dehydrated":WELLKNOWN="/var/www/dehydrated":' /etc/dehydrated/config
+sed -i 's/#CONTACT_EMAIL=/CONTACT_EMAIL="'"$email_address"'"/g' /etc/dehydrated/config
+sed -i 's/#WELLKNOWN=/WELLKNOWN=/g' /etc/dehydrated/config
 
 #accept the terms
 dehydrated --register --accept-terms --config /etc/dehydrated/config


### PR DESCRIPTION
The sed entries to update the config file was creating the following issues: 1) It was creating duplicate config files, the second has a trailing space. 2) The email variable was not passed to the config file. 3) removing the leading # from WELLKNOWN does not require the file path as it does not change. This shortened command may eliminate the creating of two config files.