### PR TITLE
Change FreeSWITCH Repo Filename for 1.10 and Newer

### DIFF
--- a/debian/resources/switch/source-release.sh
+++ b/debian/resources/switch/source-release.sh
@@ -19,15 +19,24 @@ apt install -y libshout3-dev libmpg123-dev libmp3lame-dev yasm nasm libsndfile1-
 # additional dependencies
 apt install -y sqlite3 swig3.0 unzip
 
+# function to check version numbers
+function version_gt() { test "$(printf '%s\n' "$@" | sort -V | head -n 1)" != "$1"; }
+
 #we are about to move out of the executing directory so we need to preserve it to return after we are done
 CWD=$(pwd)
 echo "Using version $switch_version"
 cd /usr/src
-#git clone -b v1.8 https://freeswitch.org/stash/scm/fs/freeswitch.git /usr/src/freeswitch
-wget http://files.freeswitch.org/freeswitch-releases/freeswitch-$switch_version-release.zip
-unzip freeswitch-$switch_version.zip
+if version_gt $switch_version '1.8.7'; then
+     wget http://files.freeswitch.org/freeswitch-releases/freeswitch-$switch_version.-release.zip
+     unzip freeswitch-$switch_version.-release.zip
+     mv freeswitch-$switch_version.-release freeswitch
+else
+     wget http://files.freeswitch.org/freeswitch-releases/freeswitch-$switch_version.zip
+     unzip freeswitch-$switch_version.zip
+     mv freeswitch-$switch_version freeswitch
+fi
 rm -R freeswitch
-mv freeswitch-$switch_version freeswitch
+#git clone -b v1.8 https://freeswitch.org/stash/scm/fs/freeswitch.git /usr/src/freeswitch
 cd /usr/src/freeswitch
 
 # bootstrap is needed if using git


### PR DESCRIPTION
(UNTESTED!)

FreeSWITCH changed the convention of files in their repository starting with 1.10.x

Old: freeswitch-1.8.7.zip
New: freeswitch-1.10.1.-release.zip

Thus it is necessary to add the .-release string to the filename when performing wget, unzip and mv. This checks version number and uses the appropriate convention accordingly depending on version.