### PR TITLE
Update node.sh to restart fail2ban if Yes is selected to update iptables rules

### DIFF
--- a/debian/resources/postgresql/node.sh
+++ b/debian/resources/postgresql/node.sh
@@ -81,6 +81,7 @@ if [ .$iptables_add = ."y" ]; then
 	echo iptables-persistent iptables-persistent/autosave_v4 boolean true | debconf-set-selections
 	echo iptables-persistent iptables-persistent/autosave_v6 boolean true | debconf-set-selections
 	apt-get install -y iptables-persistent
+	systemctl restart fail2ban
 fi
 
 #setup ssl


### PR DESCRIPTION
I noticed fail2ban was not running after node.sh completed. 
It stops after iptables-persist. I added 'systemctl restart fail2ban" to have it running properly