### PR TITLE
Fix Invoke-WebRequest Fails with SSL/TLS Secure Channel fails

### DIFF
--- a/windows/install.ps1
+++ b/windows/install.ps1
@@ -2,6 +2,8 @@
 #   Installs PostreSQL, PostgreSQL ODBC driver, PHP 7.1, GIT, Web Platform Installer,
 #   Configures ODBC, IIS, and FusionPBX
 
+[Net.ServicePointManager]::SecurityProtocol = "tls12, tls11, tls, ssl3"
+
 # includes
 . .\resources\config.ps1
 . .\resources\get-file.ps1


### PR DESCRIPTION
It seems like on Windows Server 2016 or maybe other Windows OSs powershell uses TLS 1.0 by default and the sources have different tls versions. So this will make the script work without throwing those errors.