### PR TITLE
FreeBSD install script Fix.

### DIFF
--- a/freebsd/resources/config.sh
+++ b/freebsd/resources/config.sh
@@ -3,7 +3,7 @@
 domain_name=ip_address          # hostname, ip_address or a custom value
 system_username=admin           # default username admin
 system_password=random          # random or as a pre-set value
-system_branch=stable            # master, stable
+system_branch=master            # master, stable
 
 # FreeSWITCH Settings
 switch_enabled=true             # true or false
@@ -14,7 +14,7 @@ switch_tls=true                 # true or false
 # Database Settings
 database_enabled=true           # true or false
 database_password=random        # random or as a pre-set value
-database_version=11             # Postgres 10, 9.6, 9.5, 9.4
+database_version=11             # Postgres 11, 10, 9.6, 9.5, 9.4
 database_host=127.0.0.1         # hostname or IP address
 database_port=5432              # port number
 database_backup=false           # true or false
@@ -24,7 +24,7 @@ firewall_enabled=true           # true or false
 
 # General Settings
 interface_name=auto             # auto, em0, igb0, vtnet0, or other valid names
-php_version=7.2                 # PHP version 7.2, 7.1, 5
+php_version=7.3                 # PHP version 7.4, 7.3, 7.2, 7.1, 5
 portsnap_enabled=false          # true or false
 sngrep_enabled=true             # true or false
 fail2ban_enabled=true           # true or false

--- a/freebsd/resources/config.sh
+++ b/freebsd/resources/config.sh
@@ -3,7 +3,7 @@
 domain_name=ip_address          # hostname, ip_address or a custom value
 system_username=admin           # default username admin
 system_password=random          # random or as a pre-set value
-system_branch=master            # master, stable
+system_branch=stable            # master, stable
 
 # FreeSWITCH Settings
 switch_enabled=true             # true or false
@@ -14,7 +14,7 @@ switch_tls=true                 # true or false
 # Database Settings
 database_enabled=true           # true or false
 database_password=random        # random or as a pre-set value
-database_version=10             # Postgres 10, 9.6, 9.5, 9.4
+database_version=11             # Postgres 10, 9.6, 9.5, 9.4
 database_host=127.0.0.1         # hostname or IP address
 database_port=5432              # port number
 database_backup=false           # true or false

--- a/freebsd/resources/fail2ban.sh
+++ b/freebsd/resources/fail2ban.sh
@@ -11,12 +11,14 @@ cd "$(dirname "$0")"
 verbose "Installing Fail2ban"
 
 #add the dependencies
-pkg install --yes py27-fail2ban
+pkg install --yes py37-fail2ban
 
 #enable fail2ban service
 echo 'fail2ban_enable="YES"' >> /etc/rc.conf
 
 #move the filters
+cp fail2ban/sip-auth-challenge-ip.conf /usr/local/etc/fail2ban/filter.d/sip-auth-challenge-ip.conf
+cp fail2ban/sip-auth-challenge.conf /usr/local/etc/fail2ban/filter.d/sip-auth-challenge.conf
 cp fail2ban/freeswitch-dos.conf /usr/local/etc/fail2ban/filter.d/freeswitch-dos.conf
 cp fail2ban/freeswitch-ip.conf /usr/local/etc/fail2ban/filter.d/freeswitch-ip.conf
 cp fail2ban/freeswitch-404.conf /usr/local/etc/fail2ban/filter.d/freeswitch-404.conf

--- a/freebsd/resources/nginx/fusionpbx.conf
+++ b/freebsd/resources/nginx/fusionpbx.conf
@@ -167,11 +167,11 @@ server {
 }
 
 server {
-        listen  443;
+        listen  443 ssl;
         server_name  fusionpbx;
 
 	#set tls configuration
-	ssl                     on;
+	#ssl                     on;
 	ssl_certificate         /usr/local/etc/nginx/server.crt;
 	ssl_certificate_key     /usr/local/etc/nginx/server.key;
 	ssl_protocols           TLSv1 TLSv1.1 TLSv1.2;

--- a/freebsd/resources/php.sh
+++ b/freebsd/resources/php.sh
@@ -72,6 +72,30 @@ if [ ."$php_version" = ."7.2" ]; then
     pkg install --yes php72-pdo_pgsql
   fi
 fi
+if [ ."$php_version" = ."7.3" ]; then
+  pkg install --yes php73 php73-phar php73-pdo php73-pdo_odbc php73-pdo_sqlite php73-json php73-gd php73-imap
+	pkg install --yes php73-ldap php73-openssl php73-sockets php73-simplexml php73-xml php73-session
+  if [ ."$database_version" != ."11" ]; then
+    echo "please use postgresql11."
+  fi
+  if [ ."$database_version" = ."11" ]; then
+    pkg install --yes postgresql11-client
+    pkg install --yes php73-pgsql
+    pkg install --yes php73-pdo_pgsql
+  fi
+fi
+if [ ."$php_version" = ."7.4" ]; then
+  pkg install --yes php74 php74-phar php74-pdo php74-pdo_odbc php74-pdo_sqlite php74-json php74-gd php74-imap
+	pkg install --yes php74-ldap php74-openssl php74-sockets php74-simplexml php74-xml php74-session
+  if [ ."$database_version" != ."11" ]; then
+    echo "please use postgresql11."
+  fi
+  if [ ."$database_version" = ."11" ]; then
+    pkg install --yes postgresql11-client
+    pkg install --yes php74-pgsql
+    pkg install --yes php74-pdo_pgsql
+  fi
+fi
 
 #send a message
 verbose "Configuring PHP"

--- a/freebsd/resources/php.sh
+++ b/freebsd/resources/php.sh
@@ -66,6 +66,11 @@ if [ ."$php_version" = ."7.2" ]; then
 			pkg add -f https://www.fusionpbx.com/downloads/freebsd/12/php72-pdo_pgsql-7.2.15.txz	
 		fi
 	fi
+  if [ ."$database_version" = ."11" ]; then
+    pkg install --yes postgresql11-client
+    pkg install --yes php72-pgsql
+    pkg install --yes php72-pdo_pgsql
+  fi
 fi
 
 #send a message

--- a/freebsd/resources/switch/package-release.sh
+++ b/freebsd/resources/switch/package-release.sh
@@ -16,11 +16,11 @@ cwd=$(pwd)
 echo "Installing the FreeSWITCH package"
 
 #get the package
-cd /usr/src && fetch https://www.fusionpbx.com/downloads/freebsd11/freeswitch-pgsql10-1.6.19_2.txz
+#cd /usr/src && fetch https://www.fusionpbx.com/downloads/freebsd11/freeswitch-pgsql10-1.6.19_2.txz
 
 #install the package
-#pkg install --yes freeswitch
-pkg install --yes /usr/src/freeswitch-pgsql10-1.6.19_2.txz
+pkg install --yes freeswitch
+#pkg install --yes /usr/src/freeswitch-pgsql10-1.6.19_2.txz
 
 #set the original working directory
 cd $cwd


### PR DESCRIPTION
https://www.fusionpbx.com/downloads/freebsd11/freeswitch-pgsql10-1.6.19_2.txz is a dead link.

So the install script for freebsd was changed to use the new pkg freeswitch package that is configured to use postgresql11.

Update py27-fail2ban to py37-fail2ban. python2 is end of life. 

Add php73 as default and php74 option. php72 is end of life.

nginx config file was updated because "ssl on;" is deprecated, warning fix.
nginx: [warn] the "ssl" directive is deprecated, use the "listen ... ssl" directive instead 