### PR TITLE
Few small freebsd fixes

### DIFF
--- a/freebsd/install.sh
+++ b/freebsd/install.sh
@@ -14,7 +14,7 @@ pkg upgrade --yes
 
 #Update the ports
 if [ .$portsnap_enabled = .'true' ]; then
-	if [ -f /usr/ports/UPDATING]; then
+	if [ -f /usr/ports/UPDATING ]; then
 		portsnap fetch && portsnap update
 		echo "/usr/ports updated"
 	else

--- a/freebsd/resources/fail2ban.sh
+++ b/freebsd/resources/fail2ban.sh
@@ -11,7 +11,7 @@ cd "$(dirname "$0")"
 verbose "Installing Fail2ban"
 
 #add the dependencies
-pkg install --yes py27-fail2ban
+pkg install --yes py37-fail2ban
 
 #enable fail2ban service
 echo 'fail2ban_enable="YES"' >> /etc/rc.conf

--- a/freebsd/resources/php.sh
+++ b/freebsd/resources/php.sh
@@ -1,8 +1,5 @@
 #!/bin/sh
 
-#move to script directory so all relative paths work
-cd "$(dirname "$0")"
-
 #includes
 . ./config.sh
 . ./colors.sh


### PR DESCRIPTION
1. Typo in the install.sh (missing space before "]").
2. python 2.7 is being deprecated, most of the packages including fail2ban have 3.7 version now and those that depend on Python install 3.7 by default. With the current scheme one ends up with both 2.7 and 3.7 installed.
3. There is unneded "cd" in one of the scripts, which causes error message to be printed out (php.sh is included from nginx.sh and the latter does cd resources as the first step already).

00:03:45.521  Cloning into '/usr/local/www/fusionpbx'...
Updating files: 100% (4705/4705), done.
00:03:55.135  + [ .true '=' .true ]
00:03:55.135  + resources/nginx.sh
00:03:55.135  + pwd
00:03:55.135  /tmp/fusionpbx-install.sh/freebsd
00:03:55.135  + dirname resources/nginx.sh
00:03:55.135  + cd resources
00:03:55.135  + . ./config.sh
00:03:55.135  + domain_name=ip_address
00:03:55.135  + system_username=admin
00:03:55.135  + system_password=random
00:03:55.135  + system_branch=master
00:03:55.135  + switch_enabled=true
00:03:55.135  + switch_branch=stable
00:03:55.135  + switch_source=package
00:03:55.135  + switch_tls=true
00:03:55.135  + database_enabled=true
00:03:55.135  + database_password=random
00:03:55.135  + database_version=11
00:03:55.135  + database_host=127.0.0.1
00:03:55.135  + database_port=5432
00:03:55.135  + database_backup=false
00:03:55.135  + firewall_enabled=true
00:03:55.135  + interface_name=auto
00:03:55.135  + php_version=7.3
00:03:55.135  + portsnap_enabled=false
00:03:55.135  + sngrep_enabled=true
00:03:55.135  + fail2ban_enabled=true
00:03:55.135  + nginx_enabled=true
00:03:55.135  + monit_enabled=false
00:03:55.135  + . ./colors.sh
00:03:55.135  + test -t 1
00:03:55.135  + . ./php.sh
00:03:55.135  + dirname resources/nginx.sh
00:03:55.135  + cd resources
00:03:55.135  cd: resources: No such file or directory
00:03:55.135  + . ./config.sh