### PR TITLE
Install FreeSWITCH 1.10.3 on CentOS 7

### DIFF
--- a/centos/resources/switch/package-release.sh
+++ b/centos/resources/switch/package-release.sh
@@ -14,7 +14,7 @@ verbose "Installing FreeSWITCH"
 yum -y install memcached curl gdb
 
 #install freeswitch packages
-yum install -y http://files.freeswitch.org/freeswitch-release-1-6.noarch.rpm
+yum install -y https://files.freeswitch.org/repo/yum/centos-release/freeswitch-release-repo-0-1.noarch.rpm epel-release
 yum install -y freeswitch-config-vanilla freeswitch-lang-* freeswitch-sounds-* freeswitch-lua freeswitch-xml-cdr
 
 #remove the music package to protect music on hold from package updates


### PR DESCRIPTION
Previous version of this script pulled FreeSWITCH 1.6, but there is an official RPM package available for 1.10.3.  I have tested this with my own system and haven't encountered problems.