### PR TITLE
Update letsencrypt.sh

### DIFF
--- a/debian/resources/letsencrypt.sh
+++ b/debian/resources/letsencrypt.sh
@@ -79,10 +79,10 @@ fi
 
 #request the certificates
 if [ .$wildcard_domain = ."true" ]; then
-	./dehydrated --cron --domain *.$domain_name --alias $domain_alias --config /etc/dehydrated/config --out /etc/dehydrated/certs --challenge dns-01 --hook /etc/dehydrated/hook.sh
+	./dehydrated --cron --domain *.$domain_name --alias $domain_alias --config /etc/dehydrated/config --out /etc/dehydrated/certs --challenge dns-01 --hook /etc/dehydrated/hook.sh --algo rsa
 fi
 if [ .$wildcard_domain = ."false" ]; then
-	./dehydrated --cron --alias $domain_alias --config /etc/dehydrated/config --config /etc/dehydrated/config --out /etc/dehydrated/certs --challenge http-01
+	./dehydrated --cron --alias $domain_alias --config /etc/dehydrated/config --config /etc/dehydrated/config --out /etc/dehydrated/certs --challenge http-01 --algo rsa
 fi
 
 #make sure the nginx ssl directory exists


### PR DESCRIPTION
Without specifying RSA for the algorithm, dehrydrated generated an EC private key, which caused non of my phones to be able to register. Adding --algo rsa at the end of the lines causes dehrydratated to generate an RSA private key which maintains compatibility