### PR TITLE
Update postgresql.sh

### DIFF
--- a/centos/resources/postgresql.sh
+++ b/centos/resources/postgresql.sh
@@ -15,7 +15,8 @@ password=$(dd if=/dev/urandom bs=1 count=20 2>/dev/null | base64)
 
 #included in the distribution
 #rpm -ivh --quiet http://yum.postgresql.org/9.4/redhat/rhel-7-x86_64/pgdg-centos94-9.4-3.noarch.rpm
-rpm -ivh --quiet https://yum.postgresql.org/9.6/redhat/rhel-7-x86_64/pgdg-redhat-repo-latest.noarch.rpm
+#rpm -ivh --quiet https://yum.postgresql.org/9.6/redhat/rhel-7-x86_64/pgdg-redhat-repo-latest.noarch.rpm
+rpm -ivh --quiet  https://download.postgresql.org/pub/repos/yum/reporpms/EL-7-x86_64/pgdg-redhat-repo-latest.noarch.rpm
 yum -y update
 #yum -y install postgresql94-server postgresql94-contrib postgresql94
 yum -y install postgresql96-server postgresql96-contrib postgresql96 postgresql96-libs postgresql96-devel


### PR DESCRIPTION
The link of the rpm has changed, I consult on PostgreSQL Official website (https://www.postgresql.org/download/linux/redhat/)

Script to download and install obtained from PostgreSQL
sudo yum install -y https://download.postgresql.org/pub/repos/yum/reporpms/EL-7-x86_64/pgdg-redhat-repo-latest.noarch.rpm
sudo yum install -y postgresql96-server
sudo /usr/pgsql-9.6/bin/postgresql96-setup initdb
sudo systemctl enable postgresql-9.6
sudo systemctl start postgresql-9.6