### PR TITLE
Add Preliminary Debian 11 "Bullseye" Support

### DIFF
--- a/debian/resources/ioncube.sh
+++ b/debian/resources/ioncube.sh
@@ -44,6 +44,9 @@ elif [ .$cpu_architecture = ."arm" ]; then
 fi
 
 #set the version of php
+if [ ."$os_codename" = ."bullseye" ]; then
+	php_version=7.4
+fi
 if [ ."$os_codename" = ."buster" ]; then
 	php_version=7.3
 fi
@@ -60,8 +63,8 @@ if [ ."$php_version" = ."5.6" ]; then
         cp ioncube/ioncube_loader_lin_5.6.so /usr/lib/php5/20131226
 
         #add the 00-ioncube.ini file
-        echo "zend_extension = /usr/lib/php5/20131226/ioncube_loader_lin_5.6.so" > /etc/php5/fpm/conf.d/00-ioncube.ini
-	echo "zend_extension = /usr/lib/php5/20131226/ioncube_loader_lin_5.6.so" > /etc/php5/cli/conf.d/00-ioncube.ini
+		echo "zend_extension = /usr/lib/php5/20131226/ioncube_loader_lin_5.6.so" > /etc/php5/fpm/conf.d/00-ioncube.ini
+		echo "zend_extension = /usr/lib/php5/20131226/ioncube_loader_lin_5.6.so" > /etc/php5/cli/conf.d/00-ioncube.ini
 
         #restart the service
         service php5-fpm restart
@@ -71,8 +74,8 @@ if [ ."$php_version" = ."7.0" ]; then
         cp ioncube/ioncube_loader_lin_7.0.so /usr/lib/php/20151012
 
         #add the 00-ioncube.ini file
-        echo "zend_extension = /usr/lib/php/20151012/ioncube_loader_lin_7.0.so" > /etc/php/7.0/fpm/conf.d/00-ioncube.ini
-	echo "zend_extension = /usr/lib/php/20151012/ioncube_loader_lin_7.0.so" > /etc/php/7.0/cli/conf.d/00-ioncube.ini
+		echo "zend_extension = /usr/lib/php/20151012/ioncube_loader_lin_7.0.so" > /etc/php/7.0/fpm/conf.d/00-ioncube.ini
+		echo "zend_extension = /usr/lib/php/20151012/ioncube_loader_lin_7.0.so" > /etc/php/7.0/cli/conf.d/00-ioncube.ini
 
         #restart the service
         service php7.0-fpm restart
@@ -82,8 +85,8 @@ if [ ."$php_version" = ."7.1" ]; then
         cp ioncube/ioncube_loader_lin_7.1.so /usr/lib/php/20160303
 
         #add the 00-ioncube.ini file
-        echo "zend_extension = /usr/lib/php/20160303/ioncube_loader_lin_7.1.so" > /etc/php/7.1/fpm/conf.d/00-ioncube.ini
-	echo "zend_extension = /usr/lib/php/20160303/ioncube_loader_lin_7.1.so" > /etc/php/7.1/cli/conf.d/00-ioncube.ini
+		echo "zend_extension = /usr/lib/php/20160303/ioncube_loader_lin_7.1.so" > /etc/php/7.1/fpm/conf.d/00-ioncube.ini
+		echo "zend_extension = /usr/lib/php/20160303/ioncube_loader_lin_7.1.so" > /etc/php/7.1/cli/conf.d/00-ioncube.ini
 
         #restart the service
         service php7.1-fpm restart
@@ -93,8 +96,8 @@ if [ ."$php_version" = ."7.2" ]; then
         cp ioncube/ioncube_loader_lin_7.2.so /usr/lib/php/20170718
 
         #add the 00-ioncube.ini file
-        echo "zend_extension = /usr/lib/php/20170718/ioncube_loader_lin_7.2.so" > /etc/php/7.2/fpm/conf.d/00-ioncube.ini
-	echo "zend_extension = /usr/lib/php/20170718/ioncube_loader_lin_7.2.so" > /etc/php/7.2/cli/conf.d/00-ioncube.ini
+		echo "zend_extension = /usr/lib/php/20170718/ioncube_loader_lin_7.2.so" > /etc/php/7.2/fpm/conf.d/00-ioncube.ini
+		echo "zend_extension = /usr/lib/php/20170718/ioncube_loader_lin_7.2.so" > /etc/php/7.2/cli/conf.d/00-ioncube.ini
 
         #restart the service
         service php7.2-fpm restart
@@ -104,9 +107,20 @@ if [ ."$php_version" = ."7.3" ]; then
         cp ioncube/ioncube_loader_lin_7.3.so /usr/lib/php/20180731
 
         #add the 00-ioncube.ini file
-        echo "zend_extension = /usr/lib/php/20180731/ioncube_loader_lin_7.3.so" > /etc/php/7.3/fpm/conf.d/00-ioncube.ini
-	echo "zend_extension = /usr/lib/php/20180731/ioncube_loader_lin_7.3.so" > /etc/php/7.3/cli/conf.d/00-ioncube.ini
+		echo "zend_extension = /usr/lib/php/20180731/ioncube_loader_lin_7.3.so" > /etc/php/7.3/fpm/conf.d/00-ioncube.ini
+		echo "zend_extension = /usr/lib/php/20180731/ioncube_loader_lin_7.3.so" > /etc/php/7.3/cli/conf.d/00-ioncube.ini
 
         #restart the service
         service php7.3-fpm restart
+fi
+if [ ."$php_version" = ."7.4" ]; then
+        #copy the php extension .so into the php lib directory
+        cp ioncube/ioncube_loader_lin_7.4.so /usr/lib/php/20190902
+
+        #add the 00-ioncube.ini file
+		echo "zend_extension = /usr/lib/php/20190902/ioncube_loader_lin_7.4.so" > /etc/php/7.4/fpm/conf.d/00-ioncube.ini
+		echo "zend_extension = /usr/lib/php/20190902/ioncube_loader_lin_7.4.so" > /etc/php/7.4/cli/conf.d/00-ioncube.ini
+
+        #restart the service
+        service php7.4-fpm restart
 fi

--- a/debian/resources/iptables.sh
+++ b/debian/resources/iptables.sh
@@ -16,6 +16,10 @@ if [ ."$os_codename" = ."buster" ]; then
 	update-alternatives --set iptables /usr/sbin/iptables-legacy
 	update-alternatives --set ip6tables /usr/sbin/ip6tables-legacy
 fi
+if [ ."$os_codename" = ."bullseye" ]; then
+	update-alternatives --set iptables /usr/sbin/iptables-legacy
+	update-alternatives --set ip6tables /usr/sbin/ip6tables-legacy
+fi
 
 #run iptables commands
 iptables -A INPUT -i lo -j ACCEPT

--- a/debian/resources/nginx.sh
+++ b/debian/resources/nginx.sh
@@ -23,6 +23,9 @@ if [ ."$cpu_architecture" = ."arm" ]; then
 fi
 
 #set the version of php
+if [ ."$os_codename" = ."bullseye" ]; then
+	php_version=7.4
+fi
 if [ ."$os_codename" = ."buster" ]; then
 	php_version=7.3
 fi
@@ -51,6 +54,9 @@ if [ ."$php_version" = ."7.2" ]; then
 fi
 if [ ."$php_version" = ."7.3" ]; then
         sed -i /etc/nginx/sites-available/fusionpbx -e 's#unix:.*;#unix:/var/run/php/php7.3-fpm.sock;#g'
+fi
+if [ ."$php_version" = ."7.4" ]; then
+        sed -i /etc/nginx/sites-available/fusionpbx -e 's#unix:.*;#unix:/var/run/php/php7.4-fpm.sock;#g'
 fi
 ln -s /etc/nginx/sites-available/fusionpbx /etc/nginx/sites-enabled/fusionpbx
 

--- a/debian/resources/php.sh
+++ b/debian/resources/php.sh
@@ -29,9 +29,10 @@ elif [ ."$cpu_architecture" = ."arm" ]; then
 	      php_version=7.3
 	fi
 else
-        #10.x - buster
+	#11.x - bullseye
+	#10.x - buster
 	#9.x  - stretch
-        #8.x  - jessie
+	#8.x  - jessie
 	apt-get -y install apt-transport-https lsb-release ca-certificates
 	if [ ."$os_codename" = ."jessie" ]; then
 		wget -O /etc/apt/trusted.gpg.d/php.gpg https://packages.sury.org/php/apt.gpg
@@ -44,28 +45,34 @@ else
 	if [ ."$os_codename" = ."buster" ]; then
 	      php_version=7.3
 	fi
+	if [ ."os_codename" = ."bullseye" ]; then
+	      php_version=7.4
+	fi
 fi
 apt-get update -y
 
 #install dependencies
 apt-get install -y nginx
 if [ ."$php_version" = ."" ]; then
-        apt-get install -y php php-cli php-fpm php-pgsql php-sqlite3 php-odbc php-curl php-imap php-xml php-gd
+		apt-get install -y php php-cli php-fpm php-pgsql php-sqlite3 php-odbc php-curl php-imap php-xml php-gd
 fi
 if [ ."$php_version" = ."5.6" ]; then
-        apt-get install -y php5 php5-cli php5-fpm php5-pgsql php5-sqlite php5-odbc php5-curl php5-imap php5-gd
+		apt-get install -y php5 php5-cli php5-fpm php5-pgsql php5-sqlite php5-odbc php5-curl php5-imap php5-gd
 fi
 if [ ."$php_version" = ."7.0" ]; then
-        apt-get install -y php7.0 php7.0-cli php7.0-fpm php7.0-pgsql php7.0-sqlite3 php7.0-odbc php7.0-curl php7.0-imap php7.0-xml php7.0-gd php7.0-mbstring
+		apt-get install -y php7.0 php7.0-cli php7.0-fpm php7.0-pgsql php7.0-sqlite3 php7.0-odbc php7.0-curl php7.0-imap php7.0-xml php7.0-gd php7.0-mbstring
 fi
 if [ ."$php_version" = ."7.1" ]; then
-        apt-get install -y php7.1 php7.1-cli php7.1-fpm php7.1-pgsql php7.1-sqlite3 php7.1-odbc php7.1-curl php7.1-imap php7.1-xml php7.1-gd php7.1-mbstring
+		apt-get install -y php7.1 php7.1-cli php7.1-fpm php7.1-pgsql php7.1-sqlite3 php7.1-odbc php7.1-curl php7.1-imap php7.1-xml php7.1-gd php7.1-mbstring
 fi
 if [ ."$php_version" = ."7.2" ]; then
-        apt-get install -y php7.2 php7.2-cli php7.2-fpm php7.2-pgsql php7.2-sqlite3 php7.2-odbc php7.2-curl php7.2-imap php7.2-xml php7.2-gd php7.2-mbstring
+		apt-get install -y php7.2 php7.2-cli php7.2-fpm php7.2-pgsql php7.2-sqlite3 php7.2-odbc php7.2-curl php7.2-imap php7.2-xml php7.2-gd php7.2-mbstring
 fi
 if [ ."$php_version" = ."7.3" ]; then
-        apt-get install -y php7.3 php7.3-cli php7.3-fpm php7.3-pgsql php7.3-sqlite3 php7.3-odbc php7.3-curl php7.3-imap php7.3-xml php7.3-gd php7.3-mbstring
+		apt-get install -y php7.3 php7.3-cli php7.3-fpm php7.3-pgsql php7.3-sqlite3 php7.3-odbc php7.3-curl php7.3-imap php7.3-xml php7.3-gd php7.3-mbstring
+fi
+if [ ."$php_version" = ."7.4" ]; then
+		apt-get install -y php7.4 php7.4-cli php7.4-fpm php7.4-pgsql php7.4-sqlite3 php7.4-odbc php7.4-curl php7.4-imap php7.4-xml php7.4-gd php7.4-mbstring
 fi
 
 #update config if source is being used
@@ -88,6 +95,10 @@ fi
 if [ ."$php_version" = ."7.3" ]; then
         verbose "version 7.3"
         php_ini_file='/etc/php/7.3/fpm/php.ini'
+fi
+if [ ."$php_version" = ."7.4" ]; then
+        verbose "version 7.4"
+        php_ini_file='/etc/php/7.4/fpm/php.ini'
 fi
 sed 's#post_max_size = .*#post_max_size = 80M#g' -i $php_ini_file
 sed 's#upload_max_filesize = .*#upload_max_filesize = 80M#g' -i $php_ini_file
@@ -115,6 +126,9 @@ if [ ."$php_version" = ."7.2" ]; then
 fi
 if [ ."$php_version" = ."7.3" ]; then
         systemctl restart php7.3-fpm
+fi
+if [ ."$php_version" = ."7.4" ]; then
+        systemctl restart php7.4-fpm
 fi
 
 #init.d

--- a/debian/resources/postgresql.sh
+++ b/debian/resources/postgresql.sh
@@ -42,6 +42,10 @@ if [ ."$database_repo" = ."official" ]; then
 		echo "deb http://apt.postgresql.org/pub/repos/apt/ buster-pgdg main" > /etc/apt/sources.list.d/postgresql.list
 		wget --quiet -O - https://www.postgresql.org/media/keys/ACCC4CF8.asc | sudo apt-key add -
 	fi
+	if [ ."$os_codename" = ."bullseye" ]; then
+		echo "deb http://apt.postgresql.org/pub/repos/apt/ bullseye-pgdg main" > /etc/apt/sources.list.d/postgresql.list
+		wget --quiet -O - https://www.postgresql.org/media/keys/ACCC4CF8.asc | sudo apt-key add -
+	fi
 	if [ ."$database_host" = ."127.0.0.1" ] || [ ."$database_host" = ."::1" ] ; then
 		if [ ."$database_version" = ."latest" ]; then
 			apt-get install -y sudo postgresql
@@ -64,6 +68,9 @@ if [ ."$database_repo" = ."2ndquadrant" ]; then
 		curl https://dl.2ndquadrant.com/default/release/get/deb | bash
 		if [ ."$os_codename" = ."buster" ]; then
 			sed -i /etc/apt/sources.list.d/2ndquadrant-dl-default-release.list -e 's#buster#stretch#g'
+		fi
+		if [ ."$os_codename" = ."bullseye" ]; then
+			sed -i /etc/apt/sources.list.d/2ndquadrant-dl-default-release.list -e 's#bullseye#stretch#g'
 		fi
 		apt update
 		apt-get install -y sudo postgresql-bdr-9.4 postgresql-bdr-9.4-bdr-plugin postgresql-bdr-contrib-9.4	

--- a/debian/resources/switch/source-release.sh
+++ b/debian/resources/switch/source-release.sh
@@ -25,6 +25,9 @@ fi
 if [ ."$os_codename" = ."buster" ]; then
 	apt install -y libvpx5
 fi
+if [ ."$os_codename" = ."bullseye" ]; then
+	apt install -y libvpx6
+fi
 
 # additional dependencies
 apt install -y sqlite3 swig3.0 unzip


### PR DESCRIPTION
FusionPBX will now install and run on Debian 11. 

Support for Debian 11 should be considered BETA. Use at your own risk!

Modified multiple install scripts for Debian 11 "Bullseye" support now that FreeSWITCH 1.10.7 packages officially support it. PostgreSQL was tested with 9.4 for BDR.

Changes made to the following files:

* /debian/resources/ioncube.sh
* /debian/resources/iptables.sh
* /debian/resources/nginx.sh
* /debian/resources/php.sh
* /debian/resources/postgresql.sh
* /debian/resources/switch/source-release.sh

Now using PHP 7.4 as it is the default version in Bullseye.