### PR TITLE
Add default-recordings directory

### DIFF
--- a/ubuntu/resources/switch/source-release.sh
+++ b/ubuntu/resources/switch/source-release.sh
@@ -73,5 +73,9 @@ make cd-sounds-install cd-moh-install
 mkdir -p /usr/share/freeswitch/sounds/music/default
 mv /usr/share/freeswitch/sounds/music/*000 /usr/share/freeswitch/sounds/music/default
 
+#add the default-recordings directory
+mkdir -p /var/lib/freeswitch/recordings/$domain_name
+chown -R www-data:www-data /var/lib/freeswitch/recordings/$domain_name
+
 #return to the executing directory
 cd $CWD


### PR DESCRIPTION
was missing on default-install Ubuntu 20.04.3 LTS via ubuntu-install-script