### PR TITLE
[WIP] Ubuntu - Freeswitch 1.10.7

### DIFF
--- a/ubuntu/resources/config.sh
+++ b/ubuntu/resources/config.sh
@@ -12,6 +12,9 @@ switch_package=false            # true or false
 switch_version=1.10.3           # only for source
 switch_tls=true                 # true or false
 
+# Sofia-Sip Settings
+sofia_version=1.13.6            # release-version for sofia-sip to use
+
 # Database Settings
 database_password=random        # random or a custom value (safe characters A-Z, a-z, 0-9)
 database_repo=system            # PostgreSQL official, system, 2ndquadrant

--- a/ubuntu/resources/switch/source-release.sh
+++ b/ubuntu/resources/switch/source-release.sh
@@ -41,7 +41,11 @@ then
 
 # sofia-sip
 cd /usr/src
-git clone https://github.com/freeswitch/sofia-sip.git sofia-sip
+#git clone https://github.com/freeswitch/sofia-sip.git sofia-sip
+wget https://github.com/freeswitch/sofia-sip/archive/refs/tags/v1.13.6.zip
+unzip v1.13.6.zip
+rm -R sofia-sip
+mv sofia-sip-1.13.6 sofia-sip
 cd sofia-sip
 sh autogen.sh
 ./configure

--- a/ubuntu/resources/switch/source-release.sh
+++ b/ubuntu/resources/switch/source-release.sh
@@ -42,10 +42,10 @@ then
 # sofia-sip
 cd /usr/src
 #git clone https://github.com/freeswitch/sofia-sip.git sofia-sip
-wget https://github.com/freeswitch/sofia-sip/archive/refs/tags/v1.13.6.zip
-unzip v1.13.6.zip
+wget https://github.com/freeswitch/sofia-sip/archive/refs/tags/v$sofia_version.zip
+unzip v$sofia_version.zip
 rm -R sofia-sip
-mv sofia-sip-1.13.6 sofia-sip
+mv sofia-sip-$sofia_version sofia-sip
 cd sofia-sip
 sh autogen.sh
 ./configure

--- a/ubuntu/resources/switch/source-release.sh
+++ b/ubuntu/resources/switch/source-release.sh
@@ -22,6 +22,43 @@ apt install -y swig3.0 unzip sox wget
 
 #we are about to move out of the executing directory so we need to preserve it to return after we are done
 CWD=$(pwd)
+
+if [ $(echo "$switch_version" | tr -d '.') -gt 1103 ]
+then
+# libks build-requirements
+#apt install -y cmake uuid-dev
+
+# libks
+#cd /usr/src
+#git clone https://github.com/signalwire/libks.git libks
+#cd libks
+#cmake .
+#make
+#make install
+
+# libks C includes
+#export C_INCLUDE_PATH=/usr/include/libks
+
+# sofia-sip
+cd /usr/src
+git clone https://github.com/freeswitch/sofia-sip.git sofia-sip
+cd sofia-sip
+sh autogen.sh
+./configure
+make
+make install
+
+# spandsp
+cd /usr/src
+git clone https://github.com/freeswitch/spandsp.git spandsp
+cd spandsp
+sh autogen.sh
+./configure
+make
+make install
+ldconfig
+fi
+
 echo "Using version $switch_version"
 cd /usr/src
 #git clone -b v1.8 https://freeswitch.org/stash/scm/fs/freeswitch.git /usr/src/freeswitch


### PR DESCRIPTION
This commit is a WIP for Freeswitch 1.10.7 support on Ubuntu 20.04. It adds sofia-sip and spandsp as separate dependencies.
Install: ok!

To-Dos: 
~Adjust Fail2ban-Filters like described in https://www.pbxforums.com/threads/upgrade-to-1-10-7.5743/post-23063~
Regarding Fail2ban: https://www.pbxforums.com/threads/upgrade-to-1-10-7.5743/post-23160
Testing functionality.