### PR TITLE
[WIP] Debian Bullseye - Freeswitch 1.10.7

### DIFF
--- a/debian/resources/config.sh
+++ b/debian/resources/config.sh
@@ -12,6 +12,9 @@ switch_package=true             # true or false
 switch_version=1.10.3           # only for source
 switch_tls=true                 # true or false
 
+# Sofia-Sip Settings
+sofia_version=1.13.6            # release-version for sofia-sip to use
+
 # Database Settings
 database_password=random        # random or a custom value (safe characters A-Z, a-z, 0-9)
 database_repo=official          # PostgreSQL official, system, 2ndquadrant

--- a/debian/resources/iptables.sh
+++ b/debian/resources/iptables.sh
@@ -17,6 +17,7 @@ if [ ."$os_codename" = ."buster" ]; then
 	update-alternatives --set ip6tables /usr/sbin/ip6tables-legacy
 fi
 if [ ."$os_codename" = ."bullseye" ]; then
+	apt-get install -y iptables
 	update-alternatives --set iptables /usr/sbin/iptables-legacy
 	update-alternatives --set ip6tables /usr/sbin/ip6tables-legacy
 fi

--- a/debian/resources/php.sh
+++ b/debian/resources/php.sh
@@ -75,7 +75,7 @@ if [ ."$php_version" = ."7.3" ]; then
 		apt-get install -y php7.3 php7.3-cli php7.3-fpm php7.3-pgsql php7.3-sqlite3 php7.3-odbc php7.3-curl php7.3-imap php7.3-xml php7.3-gd php7.3-mbstring
 fi
 if [ ."$php_version" = ."7.4" ]; then
-		apt-get install -y php7.4 php7.4-cli php7.4-fpm php7.4-pgsql php7.4-sqlite3 php7.4-odbc php7.4-curl php7.4-imap php7.4-xml php7.4-gd php7.4-mbstring
+		apt-get install -y php7.4 php7.4-cli php7.4-dev php7.4-fpm php7.4-pgsql php7.4-sqlite3 php7.4-odbc php7.4-curl php7.4-imap php7.4-xml php7.4-gd php7.4-mbstring
 fi
 
 #update config if source is being used

--- a/debian/resources/switch/source-release.sh
+++ b/debian/resources/switch/source-release.sh
@@ -11,7 +11,7 @@ cd "$(dirname "$0")"
 apt update && apt upgrade -y
 
 # install dependencies
-apt install -y autoconf automake devscripts g++ git-core libncurses5-dev libtool make libjpeg-dev 
+apt install -y autoconf automake devscripts g++ git-core libncurses5-dev libtool make libjpeg-dev
 apt install -y pkg-config flac  libgdbm-dev libdb-dev gettext sudo equivs mlocate git dpkg-dev libpq-dev
 apt install -y liblua5.2-dev libtiff5-dev libperl-dev libcurl4-openssl-dev libsqlite3-dev libpcre3-dev
 apt install -y devscripts libspeexdsp-dev libspeex-dev libldns-dev libedit-dev libopus-dev libmemcached-dev
@@ -20,20 +20,61 @@ apt install -y libavformat-dev libswscale-dev
 
 #install dependencies that depend on the operating system version
 if [ ."$os_codename" = ."stretch" ]; then
-	apt install -y libvpx4
+	apt install -y libvpx4 swig3.0
 fi
 if [ ."$os_codename" = ."buster" ]; then
-	apt install -y libvpx5
+	apt install -y libvpx5 swig3.0
 fi
 if [ ."$os_codename" = ."bullseye" ]; then
-	apt install -y libvpx6
+	apt install -y libvpx6 swig4.0 python3-distutils
 fi
 
 # additional dependencies
-apt install -y sqlite3 swig3.0 unzip
+apt install -y sqlite3 unzip
 
 #we are about to move out of the executing directory so we need to preserve it to return after we are done
 CWD=$(pwd)
+
+if [ $(echo "$switch_version" | tr -d '.') -gt 1103 ]
+then
+# libks build-requirements
+apt install -y cmake uuid-dev
+
+# libks
+cd /usr/src
+git clone https://github.com/signalwire/libks.git libks
+cd libks
+cmake .
+make
+make install
+
+# libks C includes
+export C_INCLUDE_PATH=/usr/include/libks
+
+# sofia-sip
+cd /usr/src
+#git clone https://github.com/freeswitch/sofia-sip.git sofia-sip
+wget https://github.com/freeswitch/sofia-sip/archive/refs/tags/v$sofia_version.zip
+unzip v$sofia_version.zip
+rm -R sofia-sip
+mv sofia-sip-$sofia_version sofia-sip
+cd sofia-sip
+sh autogen.sh
+./configure
+make
+make install
+
+# spandsp
+cd /usr/src
+git clone https://github.com/freeswitch/spandsp.git spandsp
+cd spandsp
+sh autogen.sh
+./configure
+make
+make install
+ldconfig
+fi
+
 echo "Using version $switch_version"
 cd /usr/src
 #git clone -b v1.8 https://freeswitch.org/stash/scm/fs/freeswitch.git /usr/src/freeswitch
@@ -50,7 +91,7 @@ cd /usr/src/freeswitch
 #./bootstrap.sh -j
 
 # enable required modules
-sed -i /usr/src/freeswitch/modules.conf -e s:'#applications/mod_avmd:applications/mod_avmd:'
+#sed -i /usr/src/freeswitch/modules.conf -e s:'#applications/mod_avmd:applications/mod_avmd:'
 sed -i /usr/src/freeswitch/modules.conf -e s:'#applications/mod_callcenter:applications/mod_callcenter:'
 sed -i /usr/src/freeswitch/modules.conf -e s:'#applications/mod_cidlookup:applications/mod_cidlookup:'
 sed -i /usr/src/freeswitch/modules.conf -e s:'#applications/mod_memcache:applications/mod_memcache:'


### PR DESCRIPTION
This commit is a WIP for Freeswitch 1.10.7 support on Debian 11.1 "Bullseye". It adds sofia-sip and spandsp as separate dependencies.
Install: ok!

To-Dos (same as in ubuntu-pr #378 )
~Adjust Fail2ban-Filters like described in https://www.pbxforums.com/threads/upgrade-to-1-10-7.5743/post-23063~
Regarding Fail2ban: https://www.pbxforums.com/threads/upgrade-to-1-10-7.5743/post-23160
Seems to work on my side without modification.
Testing functionality.