### PR TITLE
For FreeBSD changed default postgresql version to 13 to match the default version …

### DIFF
--- a/freebsd/resources/config.sh
+++ b/freebsd/resources/config.sh
@@ -14,7 +14,7 @@ switch_tls=true                 # true or false
 # Database Settings
 database_enabled=true           # true or false
 database_password=random        # random or as a pre-set value
-database_version=12             # Postgres 14, 13, 12, 11, 10, 9.6
+database_version=13             # Postgres 14, 13, 12, 11, 10, 9.6
 database_host=127.0.0.1         # hostname or IP address
 database_port=5432              # port number
 database_backup=false           # true or false

--- a/freebsd/resources/fail2ban.sh
+++ b/freebsd/resources/fail2ban.sh
@@ -11,7 +11,7 @@ cd "$(dirname "$0")"
 verbose "Installing Fail2ban"
 
 #add the dependencies
-pkg install --yes py37-fail2ban
+pkg install --yes py38-fail2ban
 
 #enable fail2ban service
 echo 'fail2ban_enable="YES"' >> /etc/rc.conf


### PR DESCRIPTION
…used by the freeswitch package.

changed py37-fail2ban to py38-fail2ban because the py37-fail2ban package is no longer available.