### PR TITLE
Update nginx.sh

### DIFF
--- a/ubuntu/resources/nginx.sh
+++ b/ubuntu/resources/nginx.sh
@@ -15,8 +15,8 @@ verbose "Installing the web server"
 if [ ."$cpu_architecture" = ."arm" ]; then
 	#Pi2 and Pi3 Raspbian
 	#Odroid
-	if [ ."$os_codename" = ."stretch" ]; then
-	      php_version=7.2
+	if [ ."$os_codename" = ."focal" ]; then
+	      php_version=7.4
 	else
 	      php_version=5.6
 	fi


### PR DESCRIPTION
This change will allow FusionPBX to build successfully on arm/arm64 when using Ubuntu focal.  Yhis piece of code is currently redundant anyway as its set for Debian stretch but in the Ubuntu installer