### PR TITLE
FreeSWITCH Repo change

### DIFF
--- a/debian/resources/config.sh
+++ b/debian/resources/config.sh
@@ -11,6 +11,7 @@ switch_source=false             # true or false
 switch_package=true             # true or false
 switch_version=1.10.7           # only for source
 switch_tls=true                 # true or false
+switch_token=                   # Personal Auth Token from https://signalwire.com
 
 # Sofia-Sip Settings
 sofia_version=1.13.6            # release-version for sofia-sip to use


### PR DESCRIPTION
Added a new variable to config.sh "switch_token". A Personal Access Token is now needed to pull from the Community version of FreeSWITCH.  To generate one, please create an account at https://signalwire.com More info can be found here. https://freeswitch.org/confluence/display/FREESWITCH/HOWTO+Create+a+SignalWire+Personal+Access+Token