### PR TITLE
FreeSWITCH Repo change

### DIFF
--- a/debian/resources/switch/package-release.sh
+++ b/debian/resources/switch/package-release.sh
@@ -13,9 +13,10 @@ apt-get update && apt-get install -y gnupg gnupg2
 apt-get update && apt-get install -y wget lsb-release
 
 if [ ."$cpu_architecture" = ."x86" ]; then
-	wget -O - https://files.freeswitch.org/repo/deb/debian-release/fsstretch-archive-keyring.asc | apt-key add -
-	echo "deb http://files.freeswitch.org/repo/deb/debian-release/ `lsb_release -sc` main" > /etc/apt/sources.list.d/freeswitch.list
-	echo "deb-src http://files.freeswitch.org/repo/deb/debian-release/ `lsb_release -sc` main" >> /etc/apt/sources.list.d/freeswitch.list
+	wget --http-user=signalwire --http-password=$switch_token -O /usr/share/keyrings/signalwire-freeswitch-repo.gpg https://freeswitch.signalwire.com/repo/deb/debian-release/signalwire-freeswitch-repo.gpg
+	echo "machine freeswitch.signalwire.com login signalwire password $switch_token" > /etc/apt/auth.conf
+	echo "deb [signed-by=/usr/share/keyrings/signalwire-freeswitch-repo.gpg] https://freeswitch.signalwire.com/repo/deb/debian-release/ `lsb_release -sc` main" > /etc/apt/sources.list.d/freeswitch.list
+	echo "deb-src [signed-by=/usr/share/keyrings/signalwire-freeswitch-repo.gpg] https://freeswitch.signalwire.com/repo/deb/debian-release/ `lsb_release -sc` main" >> /etc/apt/sources.list.d/freeswitch.list
 fi
 if [ ."$cpu_architecture" = ."arm" ]; then
 	wget -O - https://files.freeswitch.org/repo/deb/rpi/debian-release/freeswitch_archive_g0.pub | apt-key add -


### PR DESCRIPTION
Added a new variable to config.sh "switch_token". A Personal Access Token is now needed to pull from the Community version of FreeSWITCH.  To generate one, please create an account at https://signalwire.com More info can be found here. https://freeswitch.org/confluence/display/FREESWITCH/HOWTO+Create+a+SignalWire+Personal+Access+Token