### PR TITLE
Update fusionpbx

### DIFF
--- a/debian/resources/nginx/fusionpbx
+++ b/debian/resources/nginx/fusionpbx
@@ -176,14 +176,16 @@ server {
 }
 
 server {
-	listen 443 ssl;
+	listen 443 ssl http2;
 	server_name fusionpbx;
 
 	ssl_certificate         /etc/ssl/certs/nginx.crt;
 	ssl_certificate_key     /etc/ssl/private/nginx.key;
-	ssl_protocols           TLSv1 TLSv1.1 TLSv1.2;
-	ssl_ciphers             HIGH:!ADH:!MD5:!aNULL;
-	#ssl_dhparam
+	ssl_protocols		TLSv1.2 TLSv1.3;
+	ssl_ciphers		ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-GCM-SHA384:ECDHE-ECDSA-CHACHA20-POLY1305:ECDHE-RSA-CHACHA20-POLY1305:DHE-RSA-AES128-GCM-SHA256:DHE-RSA-AES256-GCM-SHA384;
+	ssl_session_cache	shared:SSL:40m;
+	ssl_session_timeout	2h;
+	ssl_session_tickets	off;
 
 	#redirect letsencrypt to dehydrated
 	location ^~ /.well-known/acme-challenge {


### PR DESCRIPTION
The following changes have been made:

* Enable http2 for enhanced HTTP performance
* Disable TLSv1 and TLSv1.1 which are now insecure and deprecated
* Enable TLSv1.3
* Set more specific list of enabled ciphers to reasonable balance of compliant but still secure ciphers
* Add SSL session cache to improve SSL performance in nginx

Configurations here were very heavily influenced by the following resources and tools:

https://libre-software.net/tls-nginx/
https://ssl-config.mozilla.org/#server=nginx&version=1.17.7&config=intermediate&openssl=1.1.1k&guideline=5.6
https://success.qualys.com/discussions/s/question/0D52L00004TnxRMSAZ/help-to-configure-sslciphers-in-nginx-with-tls-13-support

Note: This configuration works for provisioning Polycom, Yealink and Cisco via HTTPS on recent firmwares. We have not tested very old phones or very old firmwares, so this may impact HTTPS provisioning on very old models if they do not support TLS 1.2 or later.