### PR TITLE
This timer stops event_guard from starting too quickly after a server reboot. Unable to connect to event socket and high CPU utilization up to 90 to 99% have been observed.

### DIFF
--- a/debian/resources/finish.sh
+++ b/debian/resources/finish.sh
@@ -110,6 +110,12 @@ cp /var/www/fusionpbx/app/event_guard/resources/service/debian.service /etc/syst
 /bin/systemctl start event_guard
 /bin/systemctl daemon-reload
 
+#install the event_guard timer
+cp /var/www/fusionpbx/app/event_guard/resources/service/debian.timer /etc/systemd/system/event_guard.timer
+/bin/systemctl disable event_guard
+/bin/systemctl enable event_guard.timer
+/bin/systemctl daemon-reload
+
 #welcome message
 echo ""
 echo ""


### PR DESCRIPTION
This commit along with my other one in fusionpbx/fusionpbx resolves the issues in the topic.