### PR TITLE
Update mod_pgsql.c patch

### DIFF
--- a/debian/resources/switch/source/mod_pgsql.patch
+++ b/debian/resources/switch/source/mod_pgsql.patch
@@ -1,14 +1,53 @@
---- mod_pgsql.c	2020-05-12 10:19:16.000000000 +0000
-+++ mod_pgsql.c.modified	2022-03-18 16:54:55.956097877 +0000
-@@ -737,6 +737,11 @@
- //#endif
+--- mod_pgsql.c	2021-10-24 14:22:28.000000000 -0400
++++ mod_pgsql.c.new	2022-08-08 21:16:02.000000000 -0400
+@@ -36,6 +36,7 @@
+ #include <switch.h>
+ 
+ #include <libpq-fe.h>
++#include <pg_config.h>
+ 
+ #ifndef _WIN32
+ #include <poll.h>
+@@ -597,7 +598,7 @@
+ 		goto done;
+ 	} else {
+ 		switch (result->status) {
+-#if POSTGRESQL_MAJOR_VERSION >= 9 && POSTGRESQL_MINOR_VERSION >= 2
++#if PG_VERSION_NUM >= 90002
+ 		case PGRES_SINGLE_TUPLE:
+ 			/* Added in PostgreSQL 9.2 */
+ #endif
+@@ -756,24 +757,29 @@
+ 		*result_out = res;
+ 		res->status = PQresultStatus(res->result);
+ 		switch (res->status) {
+-//#if (POSTGRESQL_MAJOR_VERSION == 9 && POSTGRESQL_MINOR_VERSION >= 2) || POSTGRESQL_MAJOR_VERSION > 9
++#if PG_VERSION_NUM >= 90002
+ 		case PGRES_SINGLE_TUPLE:
+ 			/* Added in PostgreSQL 9.2 */
+-//#endif
++#endif
+ 		case PGRES_TUPLES_OK:
+ 		{
+ 			res->rows = PQntuples(res->result);
+ 			res->cols = PQnfields(res->result);
+ 		}
+ 		break;
+-//#if (POSTGRESQL_MAJOR_VERSION == 9 && POSTGRESQL_MINOR_VERSION >= 1) || POSTGRESQL_MAJOR_VERSION > 9
++#if PG_VERSION_NUM >= 90001
+ 		case PGRES_COPY_BOTH:
+ 			/* Added in PostgreSQL 9.1 */
+-//#endif
++#endif
  		case PGRES_COPY_OUT:
  		case PGRES_COPY_IN:
-+#if POSTGRESQL_MAJOR_VERSION >= 14
-+		case PGRES_PIPELINE_SYNC:
-+		case PGRES_PIPELINE_ABORTED:
-+ 			break;
-+#endif
  		case PGRES_COMMAND_OK:
  			break;
++#if PG_VERSION_NUM >= 140001
++		case PGRES_PIPELINE_ABORTED:
++		case PGRES_PIPELINE_SYNC:
++			break;
++#endif
  		case PGRES_EMPTY_QUERY:
+ 			switch_log_printf(SWITCH_CHANNEL_LOG, SWITCH_LOG_DEBUG, "Query (%s) returned PGRES_EMPTY_QUERY\n", handle->sql);
+ 		case PGRES_BAD_RESPONSE:


### PR DESCRIPTION
We use pgsql14 and build from source on 1.10.7 was failing again for some reason. Updated the source code to match the current freeswitch master branch and it worked fine. Updated code these differences were made from can be found here:

https://github.com/signalwire/freeswitch/commit/92d2e0b1366297b8b8fe584cd398641edbf3e803