### PR TITLE
Update fusionpbx

### DIFF
--- a/debian/resources/nginx/fusionpbx
+++ b/debian/resources/nginx/fusionpbx
@@ -53,7 +53,7 @@ server {
 }
 
 server {
-	listen 80;
+	listen [::]:80;
 	server_name fusionpbx;
 
 	#redirect letsencrypt to dehydrated
@@ -178,7 +178,7 @@ server {
 }
 
 server {
-	listen 443 ssl;
+	listen [::]:443 ssl;
 	#listen 443 ssl http2;
 	server_name fusionpbx;
 

--- a/debian/resources/nginx/fusionpbx
+++ b/debian/resources/nginx/fusionpbx
@@ -54,6 +54,7 @@ server {
 
 server {
 	listen [::]:80;
+	listen 80;
 	server_name fusionpbx;
 
 	#redirect letsencrypt to dehydrated
@@ -179,6 +180,7 @@ server {
 
 server {
 	listen [::]:443 ssl;
+	listen 443 ssl;
 	#listen 443 ssl http2;
 	server_name fusionpbx;
 


### PR DESCRIPTION
added ipv6 support to port 80 and 443 [::]: