### PR TITLE
Add command line for installing on Ubuntu/Raspbian OS

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ wget -O - https://raw.githubusercontent.com/fusionpbx/fusionpbx-install.sh/maste
 cd /usr/src/fusionpbx-install.sh/debian && ./install.sh
 ```
 
-### Ubuntu/Raspbian
+### Ubuntu and Raspiberry OS
 ```sh
 wget -O - https://raw.githubusercontent.com/fusionpbx/fusionpbx-install.sh/master/ubuntu/pre-install.sh | sh;
 cd /usr/src/fusionpbx-install.sh/ubuntu && ./install.sh

--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@ FusionPBX Install
 A quick install guide & scripts for installing FusionPBX. It is recommended to start with a minimal install of the operating system. Notes on further tweaking your configuration are at end of the file.
 
 ## Operating Systems
+
 ### Debian
 Debian is the preferred operating system by the FreeSWITCH developers. It supports the latest video dependencies and should be used if you want to do video mixing. Download Debian at https://cdimage.debian.org/cdimage/release/current/
 
@@ -11,6 +12,13 @@ Debian is the preferred operating system by the FreeSWITCH developers. It suppor
 wget -O - https://raw.githubusercontent.com/fusionpbx/fusionpbx-install.sh/master/debian/pre-install.sh | sh;
 cd /usr/src/fusionpbx-install.sh/debian && ./install.sh
 ```
+
+### Ubuntu/Raspbian
+```sh
+wget -O - https://raw.githubusercontent.com/fusionpbx/fusionpbx-install.sh/master/ubuntu/pre-install.sh | sh;
+cd /usr/src/fusionpbx-install.sh/ubuntu && ./install.sh
+```
+
 ### Devuan
 If you like Debian but rather not bother with systemd, Devuan is a "drop in" replacement.
 Devuan ASCII is based on Stretch, so you will find most of the same packages available.

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ wget -O - https://raw.githubusercontent.com/fusionpbx/fusionpbx-install.sh/maste
 cd /usr/src/fusionpbx-install.sh/debian && ./install.sh
 ```
 
-### Ubuntu and Raspiberry OS
+### Ubuntu and Raspian
 ```sh
 wget -O - https://raw.githubusercontent.com/fusionpbx/fusionpbx-install.sh/master/ubuntu/pre-install.sh | sh;
 cd /usr/src/fusionpbx-install.sh/ubuntu && ./install.sh

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ wget -O - https://raw.githubusercontent.com/fusionpbx/fusionpbx-install.sh/maste
 cd /usr/src/fusionpbx-install.sh/debian && ./install.sh
 ```
 
-### Ubuntu and Raspian
+### Ubuntu and Raspberry OS
 ```sh
 wget -O - https://raw.githubusercontent.com/fusionpbx/fusionpbx-install.sh/master/ubuntu/pre-install.sh | sh;
 cd /usr/src/fusionpbx-install.sh/ubuntu && ./install.sh


### PR DESCRIPTION
Hi, I saw that the repo has a folder for installing it on Ubuntu, but the README.md did not have such a command line to help users to copy and paste it quickly. So I added it. I am interested in installing this on a Raspberry Pi, so I also added this name with Ubuntu since I thing they are quite compatible. 