### PR TITLE
Update fusionpbx-maintenance

### DIFF
--- a/debian/resources/backup/fusionpbx-maintenance
+++ b/debian/resources/backup/fusionpbx-maintenance
@@ -77,7 +77,7 @@ if [ .$purge_call_recordings = .true ]; then
 		find /usr/local/freeswitch/recordings/*/archive/*  -name '*.wav' -mtime +$days_keep_call_recordings -exec rm {} \;
 		find /usr/local/freeswitch/recordings/*/archive/*  -name '*.mp3' -mtime +$days_keep_call_recordings -exec rm {} \;
 	fi
-	#Call recordings table uses a view. The data is from v_xml_cdr table. Changed in FusionPBX 5.0.7 and higher. The following line is useful only to older versions.
+	#Call recordings table uses a view. The data is from v_xml_cdr table. Changed in FusionPBX 5.0.7 and higher. The following line is useful to older versions.
 	#psql --host=127.0.0.1 --username=fusionpbx -c "delete from v_call_recordings WHERE call_recording_date < NOW() - INTERVAL '90 days'"
 else
 	echo "not purging Recordings."

--- a/debian/resources/backup/fusionpbx-maintenance
+++ b/debian/resources/backup/fusionpbx-maintenance
@@ -77,7 +77,8 @@ if [ .$purge_call_recordings = .true ]; then
 		find /usr/local/freeswitch/recordings/*/archive/*  -name '*.wav' -mtime +$days_keep_call_recordings -exec rm {} \;
 		find /usr/local/freeswitch/recordings/*/archive/*  -name '*.mp3' -mtime +$days_keep_call_recordings -exec rm {} \;
 	fi
-	psql --host=127.0.0.1 --username=fusionpbx -c "delete from v_call_recordings WHERE call_recording_date < NOW() - INTERVAL '90 days'"
+	#table v_call_recordings became a view instead (called view_call_recordings) in FusionPBX 5.0.7+, so the following line is no longer necessary
+	#psql --host=127.0.0.1 --username=fusionpbx -c "delete from v_call_recordings WHERE call_recording_date < NOW() - INTERVAL '90 days'"
 else
 	echo "not purging Recordings."
 fi

--- a/debian/resources/backup/fusionpbx-maintenance
+++ b/debian/resources/backup/fusionpbx-maintenance
@@ -77,7 +77,7 @@ if [ .$purge_call_recordings = .true ]; then
 		find /usr/local/freeswitch/recordings/*/archive/*  -name '*.wav' -mtime +$days_keep_call_recordings -exec rm {} \;
 		find /usr/local/freeswitch/recordings/*/archive/*  -name '*.mp3' -mtime +$days_keep_call_recordings -exec rm {} \;
 	fi
-	#table v_call_recordings became a view instead (called view_call_recordings) in FusionPBX 5.0.7+, so the following line is no longer necessary
+	#Call recordings table uses a view. The data is from v_xml_cdr table. Changed in FusionPBX 5.0.7 and higher. The following line is useful only to older versions.
 	#psql --host=127.0.0.1 --username=fusionpbx -c "delete from v_call_recordings WHERE call_recording_date < NOW() - INTERVAL '90 days'"
 else
 	echo "not purging Recordings."


### PR DESCRIPTION
Comment out command that purges the v_call_recordings table, as was turned into a view in FusionPBX 5.0.7+.  So, call recording data should now be managed only in the v_xml_cdr table instead.