### PR TITLE
Update FreeBSD code

### DIFF
--- a/freebsd/resources/backup/fusionpbx-backup.sh
+++ b/freebsd/resources/backup/fusionpbx-backup.sh
@@ -22,6 +22,6 @@ pg_dump --verbose -Fc --host=$db_host --port=$db_port -U fusionpbx fusionpbx --s
 #tar -zvcf /var/backups/fusionpbx/backup_$now.tgz /var/backups/fusionpbx/postgresql/fusionpbx_pgsql_$now.sql /var/www/fusionpbx /usr/share/freeswitch/scripts /var/lib/freeswitch/storage /var/lib/freeswitch/recordings /etc/fusionpbx /etc/freeswitch
 
 #source
-tar -zvcf /var/backups/fusionpbx/backup_$now.tgz /var/backups/fusionpbx/postgresql/fusionpbx_pgsql_$now.sql /usr/local/www/fusionpbx /usr/local/freeswitch/scripts /usr/local/freeswitch/storage /usr/local/freeswitch/recordings /etc/fusionpbx /usr/local/freeswitch/conf
+tar -zvcf /var/backups/fusionpbx/backup_$now.tgz /var/backups/fusionpbx/postgresql/fusionpbx_pgsql_$now.sql /var/www/fusionpbx /usr/local/freeswitch/scripts /usr/local/freeswitch/storage /usr/local/freeswitch/recordings /etc/fusionpbx /usr/local/freeswitch/conf
 
 echo "Backup Completed"

--- a/freebsd/resources/config.sh
+++ b/freebsd/resources/config.sh
@@ -3,7 +3,7 @@
 domain_name=ip_address          # hostname, ip_address or a custom value
 system_username=admin           # default username admin
 system_password=random          # random or as a pre-set value
-system_branch=master            # master, stable
+system_branch=5.1               # master, stable
 
 # FreeSWITCH Settings
 switch_enabled=true             # true or false
@@ -16,7 +16,7 @@ database_name=fusionpbx         # Database name (safe characters A-Z, a-z, 0-9)
 database_username=fusionpbx     # Database username (safe characters A-Z, a-z, 0-9)
 database_password=random        # random or a custom value (safe characters A-Z, a-z, 0-9)
 database_enabled=true           # true or false
-database_version=13             # Postgres 14, 13, 12, 11, 10, 9.6
+database_version=13             # Postgres 15, 14, 13, 12, 11
 database_host=127.0.0.1         # hostname or IP address
 database_port=5432              # port number
 database_backup=false           # true or false
@@ -26,8 +26,8 @@ firewall_enabled=true           # true or false
 
 # General Settings
 interface_name=auto             # auto, em0, igb0, vtnet0, or other valid names
-php_version=8.1                 # PHP version 8.1, 7.4
-portsnap_enabled=false           # true or false
+php_version=8.1                 # PHP version 8.3, 8.2, 8.1, 8.0
+portsnap_enabled=false          # true or false
 sngrep_enabled=true             # true or false
 fail2ban_enabled=true           # true or false
 nginx_enabled=true              # true or false

--- a/freebsd/resources/finish.sh
+++ b/freebsd/resources/finish.sh
@@ -37,7 +37,7 @@ if [ .$nginx_enabled = .'true' ]; then
 	sed -i' ' -e s:"{database_password}:$database_password:" /usr/local/etc/fusionpbx/config.conf
 
 	#add the database schema
-	cd /usr/local/www/fusionpbx && /usr/local/bin/php /usr/local/www/fusionpbx/core/upgrade/upgrade_schema.php > /dev/null 2>&1
+	cd /var/www/fusionpbx && /usr/local/bin/php /var/www/fusionpbx/core/upgrade/upgrade_schema.php > /dev/null 2>&1
 
 	#get the primary interface name
 	if [ .$interface_name = .'auto' ]; then
@@ -67,11 +67,11 @@ if [ .$nginx_enabled = .'true' ]; then
 	psql --host=$database_host --port=$database_port --username=$database_username -c "insert into v_domains (domain_uuid, domain_name, domain_enabled) values('$domain_uuid', '$domain_name', 'true');"
 
 	#app defaults
-	cd /usr/local/www/fusionpbx && /usr/local/bin/php /usr/local/www/fusionpbx/core/upgrade/upgrade_domains.php
+	cd /var/www/fusionpbx && /usr/local/bin/php /var/www/fusionpbx/core/upgrade/upgrade_domains.php
 
 	#add the user
-	user_uuid=$(/usr/local/bin/php /usr/local/www/fusionpbx/resources/uuid.php);
-	user_salt=$(/usr/local/bin/php /usr/local/www/fusionpbx/resources/uuid.php);
+	user_uuid=$(/usr/local/bin/php /var/www/fusionpbx/resources/uuid.php);
+	user_salt=$(/usr/local/bin/php /var/www/fusionpbx/resources/uuid.php);
 	user_name=$system_username
 	if [ .$system_password = .'random' ]; then
 		user_password=$(cat /dev/random | env LC_CTYPE=C tr -dc a-zA-Z0-9 | head -c 20)
@@ -86,7 +86,7 @@ if [ .$nginx_enabled = .'true' ]; then
 	group_uuid=$(echo $group_uuid | sed 's/^[[:blank:]]*//;s/[[:blank:]]*$//')
 
 	#add the user to the group
-	user_group_uuid=$(/usr/local/bin/php /usr/local/www/fusionpbx/resources/uuid.php);
+	user_group_uuid=$(/usr/local/bin/php /var/www/fusionpbx/resources/uuid.php);
 	group_name=superadmin
 	psql --host=$database_host --port=$database_port --username=$database_username -c "insert into v_user_groups (user_group_uuid, domain_uuid, group_name, group_uuid, user_uuid) values('$user_group_uuid', '$domain_uuid', '$group_name', '$group_uuid', '$user_uuid');"
 
@@ -95,7 +95,7 @@ if [ .$nginx_enabled = .'true' ]; then
 
 	#app defaults
 	if [ .$nginx_enabled = .'true' ]; then
-		cd /usr/local/www/fusionpbx && php /usr/local/www/fusionpbx/core/upgrade/upgrade_domains.php
+		cd /var/www/fusionpbx && php /var/www/fusionpbx/core/upgrade/upgrade_domains.php
 	fi
 
 	#reset the current working directory

--- a/freebsd/resources/fusionpbx.sh
+++ b/freebsd/resources/fusionpbx.sh
@@ -28,5 +28,6 @@ mkdir -p /var/cache/fusionpbx
 chown -R www:www /var/cache/fusionpbx
 
 #get the source code
+ln -s /usr/local/www /var/www
 git clone $branch https://github.com/fusionpbx/fusionpbx.git /usr/local/www/fusionpbx
 chown -R www:www /usr/local/www/fusionpbx

--- a/freebsd/resources/fusionpbx/config.conf
+++ b/freebsd/resources/fusionpbx/config.conf
@@ -14,7 +14,7 @@ database.1.path = /var/lib/freeswitch/db
 database.1.name = core.db
 
 #general settings
-document.root = /usr/local/www/fusionpbx
+document.root = /var/www/fusionpbx
 project.path =
 temp.dir = /tmp
 php.dir = /usr/local/bin

--- a/freebsd/resources/letsencrypt.sh
+++ b/freebsd/resources/letsencrypt.sh
@@ -18,7 +18,7 @@ cd "$(dirname "$0")"
 #rm /usr/local/sbin/dehydrated
 #rm -R /usr/src/dehydrated
 #rm -R /usr/src/dns-01-manual
-#rm -R /usr/local/www/dehydrated
+#rm -R /var/www/dehydrated
 
 #request the domain name, email address and wild card domain
 read -p 'Domain Name: ' domain_name
@@ -29,7 +29,7 @@ pkg install dehydrated
 #cd /usr/src && git clone https://github.com/lukas2511/dehydrated.git
 #cd /usr/src/dehydrated
 #cp dehydrated /usr/local/sbin
-#mkdir -p /usr/local/www/dehydrated
+#mkdir -p /var/www/dehydrated
 #mkdir -p /usr/local/etc/dehydrated/certs
 
 #wildcard detection

--- a/freebsd/resources/nginx.sh
+++ b/freebsd/resources/nginx.sh
@@ -48,7 +48,7 @@ common_name=$local_ip_v4
     -keyout /usr/local/etc/nginx/server.key -out /usr/local/etc/nginx/server.crt
 
 #add the letsencrypt directory
-mkdir -p /var/www/letsencrypt/
+mkdir -p /usr/local/www/letsencrypt/
 
 #restart php fpm and nginx
 service php-fpm restart

--- a/freebsd/resources/nginx/fusionpbx.conf
+++ b/freebsd/resources/nginx/fusionpbx.conf
@@ -9,7 +9,7 @@ server {
 
 	#set the default index files
 	location / {
-		root   /usr/local/www/fusionpbx;
+		root   /var/www/fusionpbx;
 		index  index.php index.html index.htm;
 	}
 
@@ -20,14 +20,14 @@ server {
 	#http error handling
 	error_page   500 502 503 504  /50x.html;
 	location = /50x.html {
-		root   /usr/local/www/nginx-dist;
+		root   /var/www/nginx-dist;
 	}
 
 	#pass the PHP scripts to FastCGI server listening on 127.0.0.1:9000
 	location ~ \.php$ {
 		fastcgi_pass   127.0.0.1:9000;
 		fastcgi_index  index.php;
-		fastcgi_param  SCRIPT_FILENAME  /usr/local/www/fusionpbx$fastcgi_script_name;
+		fastcgi_param  SCRIPT_FILENAME  /var/www/fusionpbx$fastcgi_script_name;
 		include        fastcgi_params;
 	}
 
@@ -61,12 +61,12 @@ server {
 	location ^~ /.well-known/acme-challenge {
 		default_type "text/plain";
 		auth_basic "off";
-		alias /usr/local/www/dehydrated;
+		alias /var/www/dehydrated;
 	}
 
 	#set the default index files
 	location / {
-		root   /usr/local/www/fusionpbx;
+		root   /var/www/fusionpbx;
 		index  index.php index.html index.htm;
 	}
 
@@ -136,14 +136,14 @@ server {
 	#http error handling
 	error_page   500 502 503 504  /50x.html;
 	location = /50x.html {
-		root   /usr/local/www/nginx-dist;
+		root   /var/www/nginx-dist;
 	}
 	
 	#pass the PHP scripts to FastCGI server listening on 127.0.0.1:9000
 	location ~ \.php$ {
 		fastcgi_pass   127.0.0.1:9000;
 		fastcgi_index  index.php;
-		fastcgi_param  SCRIPT_FILENAME  /usr/local/www/fusionpbx$fastcgi_script_name;
+		fastcgi_param  SCRIPT_FILENAME  /var/www/fusionpbx$fastcgi_script_name;
 		include        fastcgi_params;
 	}
 
@@ -183,12 +183,12 @@ server {
 	location ^~ /.well-known/acme-challenge {
 		default_type "text/plain";
 		auth_basic "off";
-		alias /usr/local/www/dehydrated;
+		alias /var/www/dehydrated;
 	}
 
 	#set the default index files
 	location / {
-		root   /usr/local/www/fusionpbx;
+		root   /var/www/fusionpbx;
 		index  index.php index.html index.htm;
 	}
 
@@ -260,14 +260,14 @@ server {
 	#http error handling
 	error_page   500 502 503 504  /50x.html;
 	location = /50x.html {
-		root   /usr/local/www/nginx-dist;
+		root   /var/www/nginx-dist;
 	}
 
 	#pass the PHP scripts to FastCGI server listening on 127.0.0.1:9000
 	location ~ \.php$ {
 		fastcgi_pass   127.0.0.1:9000;
 		fastcgi_index  index.php;
-		fastcgi_param  SCRIPT_FILENAME  /usr/local/www/fusionpbx$fastcgi_script_name;
+		fastcgi_param  SCRIPT_FILENAME  /var/www/fusionpbx$fastcgi_script_name;
 		include        fastcgi_params;
 	}
 

--- a/freebsd/resources/php.sh
+++ b/freebsd/resources/php.sh
@@ -12,25 +12,25 @@ echo "DEFAULT_VERSIONS+=pgsql=$database_version" >> /etc/make.conf
 echo "DEFAULT_VERSIONS+=ssl=openssl" >> /etc/make.conf
 
 #install dependencies
-if [ ."$php_version" = ."7.3" ]; then
-	pkg install --yes php73 php73-phar php73-pdo php73-pdo_odbc php73-pdo_sqlite php73-json php73-gd php73-imap
-	pkg install --yes php73-ldap php73-openssl php73-sockets php73-simplexml php73-xml php73-session php73-iconv
-	pkg install --yes php73-zlib php73-filter php73-pdo_pgsql php73-pgsql php73-curl php73-mbstring
-fi
-if [ ."$php_version" = ."7.4" ]; then
-	pkg install --yes php74 php74-phar php74-pdo php74-pdo_odbc php74-pdo_sqlite php74-json php74-gd php74-imap
-	pkg install --yes php74-ldap php74-openssl php74-sockets php74-simplexml php74-xml php74-session php74-iconv
-	pkg install --yes php74-zlib php74-filter php74-pdo_pgsql php74-pgsql php74-curl php74-mbstring
-fi
 if [ ."$php_version" = ."8.0" ]; then
-	pkg install --yes php80 php80-phar php80-pdo php80-pdo_odbc php80-pdo_sqlite php80-gd php80-imap
-	pkg install --yes php80-ldap php80-sockets php80-simplexml php80-xml php80-session php80-iconv
-	pkg install --yes php80-zlib php80-filter php80-pdo_pgsql php80-pgsql php80-curl php80-mbstring
+	pkg install --yes php80 php80-phar php80-pdo php80-pdo_odbc php80-pdo_sqlite php80-gd php80-imap \
+		php80-ldap php80-sockets php80-simplexml php80-xml php80-session php80-iconv php80-zlib \
+		php80-filter postgresql13-client php80-pdo_pgsql php80-pgsql php80-curl php80-mbstring
 fi
 if [ ."$php_version" = ."8.1" ]; then
-	pkg install --yes php81 php81-phar php81-pdo php81-pdo_odbc php81-pdo_sqlite php81-gd php81-imap
-	pkg install --yes php81-ldap php81-sockets php81-simplexml php81-xml php81-session php81-iconv
-	pkg install --yes php81-zlib php81-filter php81-pdo_pgsql php81-pgsql php81-curl php81-mbstring
+	pkg install --yes php81 php81-phar php81-pdo php81-pdo_odbc php81-pdo_sqlite php81-gd php81-imap \
+		php81-ldap php81-sockets php81-simplexml php81-xml php81-session php81-iconv php81-zlib \
+		php81-filter postgresql13-client php81-pdo_pgsql php81-pgsql php81-curl php81-mbstring
+fi
+if [ ."$php_version" = ."8.2" ]; then
+	pkg install --yes php82 php82-phar php82-pdo php82-pdo_odbc php82-pdo_sqlite php82-gd php82-imap \
+		php82-ldap php82-sockets php82-simplexml php82-xml php82-session php82-iconv php82-zlib \
+		php82-filter postgresql13-client php82-pdo_pgsql php82-pgsql php82-curl php82-mbstring
+fi
+if [ ."$php_version" = ."8.3" ]; then
+	pkg install --yes php83 php83-phar php83-pdo php83-pdo_odbc php83-pdo_sqlite php83-gd php83-imap \
+		php83-ldap php83-sockets php83-simplexml php83-xml php83-session php83-iconv php83-zlib \
+		php83-filter postgresql13-client php83-pdo_pgsql php83-pgsql php83-curl php83-mbstring
 fi
 #send a message
 verbose "Configuring PHP"

--- a/freebsd/resources/postgresql.sh
+++ b/freebsd/resources/postgresql.sh
@@ -24,6 +24,14 @@ password=$(cat /dev/random | env LC_CTYPE=C tr -dc a-zA-Z0-9 | head -c 20)
 echo "Install PostgreSQL and create the database and users\n"
 
 #postgres install
+if [ ."$database_version" = ."15" ]; then
+	pkg install --yes postgresql15-server
+	#cd /usr/ports/databases/postgresql15-server/ && make install clean BATCH=yes
+fi
+if [ ."$database_version" = ."14" ]; then
+	pkg install --yes postgresql14-server
+	#cd /usr/ports/databases/postgresql14-server/ && make install clean BATCH=yes
+fi
 if [ ."$database_version" = ."13" ]; then
 	pkg install --yes postgresql13-server
 	#cd /usr/ports/databases/postgresql13-server/ && make install clean BATCH=yes
@@ -36,26 +44,6 @@ if [ ."$database_version" = ."11" ]; then
 	pkg install --yes postgresql11-server
 	#cd /usr/ports/databases/postgresql11-server/ && make install clean BATCH=yes
 fi
-if [ ."$database_version" = ."10" ]; then
-	pkg install --yes postgresql10-server
-	#cd /usr/ports/databases/postgresql10-server/ && make install clean BATCH=yes
-fi
-if [ ."$database_version" = ."9.6" ]; then
-	pkg install --yes postgresql96-server
-	#cd /usr/ports/databases/postgresql96-server/ && make install clean BATCH=yes
-fi
-if [ ."$database_version" = ."9.5" ]; then
-        pkg install --yes postgresql95-server
-	#cd /usr/ports/databases/postgresql95-server/ && make install clean BATCH=yes
-fi
-if [ ."$database_version" = ."9.4" ]; then
-        pkg install --yes postgresql94-server
-	#cd /usr/ports/databases/postgresql94-server/ && make install clean BATCH=yes
-fi
-if [ ."$database_version" = ."9.3" ]; then
-        pkg install --yes postgresql93-server
-	#cd /usr/ports/databases/postgresql93-server/ && make install clean BATCH=yes
-fi
 
 #enable postgres
 echo 'postgresql_enable=true' >> /etc/rc.conf
@@ -64,6 +52,12 @@ echo 'postgresql_enable=true' >> /etc/rc.conf
 /usr/local/etc/rc.d/postgresql initdb
 
 #start postgresql
+if [ ."$database_version" = ."15" ]; then
+	sudo -u postgres /usr/local/bin/pg_ctl -D /var/db/postgres/data15 start
+fi
+if [ ."$database_version" = ."14" ]; then
+	sudo -u postgres /usr/local/bin/pg_ctl -D /var/db/postgres/data14 start
+fi
 if [ ."$database_version" = ."13" ]; then
 	sudo -u postgres /usr/local/bin/pg_ctl -D /var/db/postgres/data13 start
 fi
@@ -72,21 +66,6 @@ if [ ."$database_version" = ."12" ]; then
 fi
 if [ ."$database_version" = ."11" ]; then
 	sudo -u postgres /usr/local/bin/pg_ctl -D /var/db/postgres/data11 start
-fi
-if [ ."$database_version" = ."10" ]; then
-	sudo -u postgres /usr/local/bin/pg_ctl -D /var/db/postgres/data10 start
-fi
-if [ ."$database_version" = ."9.6" ]; then
-	sudo -u postgres /usr/local/bin/pg_ctl -D /var/db/postgres/data96 start
-fi
-if [ ."$database_version" = ."9.5" ]; then
-	sudo -u postgres /usr/local/bin/pg_ctl -D /var/db/postgres/data95 start
-fi
-if [ ."$database_version" = ."9.4" ]; then
-	sudo -u postgres /usr/local/bin/pg_ctl -D /var/db/postgres/data94 start
-fi
-if [ ."$database_version" = ."9.3" ]; then
-	sudo -u pgsql /usr/local/bin/pg_ctl -D /usr/local/pgsql/data start
 fi
 
 #restart the service

--- a/freebsd/resources/switch/package-copy.sh
+++ b/freebsd/resources/switch/package-copy.sh
@@ -5,8 +5,8 @@
 
 #copy the default conf directory
 mkdir -p /usr/local/etc/freeswitch
-cp -R /usr/local/www/fusionpbx/app/switch/resources/conf/* /usr/local/etc/freeswitch
+cp -R /var/www/fusionpbx/app/switch/resources/conf/* /usr/local/etc/freeswitch
 
 #copy the scripts
-cp -R /usr/local/www/fusionpbx/app/scripts/resources/scripts /usr/local/share/freeswitch
+cp -R /var/www/fusionpbx/app/switch/resources/scripts /usr/local/share/freeswitch
 chown -R www:www /usr/local/share/freeswitch

--- a/freebsd/resources/switch/package-release.sh
+++ b/freebsd/resources/switch/package-release.sh
@@ -7,7 +7,7 @@ cd "$(dirname "$0")"
 . ../config.sh
 
 #install dependencies
-pkg install --yes tiff ghostscript9-base memcached sox
+pkg install --yes tiff ghostscript10 memcached sox
 
 #set the current working directory
 cwd=$(pwd)
@@ -35,8 +35,8 @@ cd $cwd
 echo 'memcached_enable="YES"' >> /etc/rc.conf
 echo 'freeswitch_enable="YES"' >> /etc/rc.conf
 echo 'freeswitch_flags="-nonat"' >> /etc/rc.conf
-echo 'freeswitch_user="www"' >> /etc/rc.conf
-echo 'freeswitch_group="www"' >> /etc/rc.conf
+echo 'freeswitch_username="www"' >> /etc/rc.conf
+echo 'freeswitch_groupname="www"' >> /etc/rc.conf
 
 #start the service
 service memcached start

--- a/freebsd/resources/switch/source-copy.sh
+++ b/freebsd/resources/switch/source-copy.sh
@@ -5,8 +5,8 @@ mv /usr/local/freeswitch/conf /usr/local/freeswitch/conf.orig
 
 #copy the default conf directory
 mkdir -p /usr/local/freeswitch/conf
-cp -R /usr/local/www/fusionpbx/app/switch/resources/conf/* /usr/local/freeswitch/conf
+cp -R /var/www/fusionpbx/app/switch/resources/conf/* /usr/local/freeswitch/conf
 
 #copy the scripts
-cp -R /usr/local/www/fusionpbx/resources/install/scripts /usr/local/freeswitch
+cp -R /var/www/fusionpbx/resources/install/scripts /usr/local/freeswitch
 chown -R www:www /usr/local/freeswitch

--- a/freebsd/resources/switch/source-master.sh
+++ b/freebsd/resources/switch/source-master.sh
@@ -13,7 +13,7 @@ cwd=$(pwd)
 echo "Installing the FreeSWITCH source"
 
 #install minimum dependencies
-pkg install --yes autoconf automake curl git gmake ldns libedit libtool openssl pcre pkgconf speex sqlite3
+pkg install --yes autoconf automake curl git-lite gmake ldns libedit libtool openssl pcre pkgconf speex sqlite3
 pkg install --yes wget sudo libsndfile lua52 opus libmemcached libvorbis libogg tiff memcached
 
 #additional dependencies

--- a/freebsd/resources/switch/source-release.sh
+++ b/freebsd/resources/switch/source-release.sh
@@ -13,9 +13,9 @@ cwd=$(pwd)
 echo "Installing the FreeSWITCH source"
 
 #install minimum dependencies
-pkg install --yes autoconf automake curl git gmake ldns libedit libtool openssl pcre pkgconf speex sqlite3
+pkg install --yes autoconf automake curl git-lite gmake ldns libedit libtool openssl pcre pkgconf speex sqlite3
 pkg install --yes gcc10 wget sudo libsndfile lua52 opus libmemcached libvorbis libogg tiff memcached
-pkg install --yes spandsp sofia-sip postgresql${database_version}-client sox
+pkg install --yes spandsp sofia-sip sox
 
 #additional dependencies
 #pkg install --yes libshout mpg123 lame opencore-amr vo-amrwbenc gtar gumbo libyaml flite h2o python3 pocketsphinx erlang ffmpeg


### PR DESCRIPTION
- While /usr/local/www/ is the correct prefix, the FusionPBX code itself still refers to /var/www/. So instead of fighting it, let's just symlink it.
- Updated the supported versions of PgSQL and PHP
- Moved the PgSQL client version logic to the PHP code, since we depend on the version of client that PHP is linked against. That's currently 13, so to make it clean, let's just default to 13 for now.

After these changes, 5.1 appears to be fully functional for me. I had DB schema issues with master, but I ran into the same issue on Debian, so maybe it was a temporary master issue?