### PR TITLE
Remove unsupported error for aarch64 Linux

### DIFF
--- a/debian/resources/environment.sh
+++ b/debian/resources/environment.sh
@@ -69,7 +69,6 @@ if [ .$cpu_architecture = .'arm' ]; then
 	if [ .$os_mode = .'32' ]; then
 		verbose "Correct CPU and Operating System detected, using the ARM repo"
 	elif [ .$os_mode = .'64' ]; then
-		error "You are using a 64bit arm OS this is unsupported"
 		switch_source=true
 		switch_package=false
 	else

--- a/debian/resources/switch/source-master.sh
+++ b/debian/resources/switch/source-master.sh
@@ -25,7 +25,7 @@ sed -i /usr/src/freeswitch/modules.conf -e s:'#formats/mod_pgsql:formats/mod_pgs
 ./configure --prefix=/usr/local/freeswitch --enable-core-pgsql-support --disable-fhs
 
 #make mod_shout-install
-make
+make -j $(getconf _NPROCESSORS_ONLN)
 rm -rf /usr/local/freeswitch/{lib,mod,bin}/*
 make install
 make sounds-install moh-install

--- a/debian/resources/switch/source-release.sh
+++ b/debian/resources/switch/source-release.sh
@@ -46,7 +46,7 @@ if [ $(echo "$switch_version" | tr -d '.') -gt 1100 ]; then
 	git clone https://github.com/signalwire/libks.git libks
 	cd libks
 	cmake .
-	make
+	make -j $(getconf _NPROCESSORS_ONLN)
 	make install
 
 	# libks C includes
@@ -62,7 +62,7 @@ if [ $(echo "$switch_version" | tr -d '.') -gt 1100 ]; then
 	cd sofia-sip
 	sh autogen.sh
 	./configure
-	make
+	make -j $(getconf _NPROCESSORS_ONLN)
 	make install
 
 	# spandsp
@@ -73,7 +73,7 @@ if [ $(echo "$switch_version" | tr -d '.') -gt 1100 ]; then
  	#/usr/bin/sed -i 's/AC_PREREQ(\[2\.71\])/AC_PREREQ([2.69])/g' /usr/src/spandsp/configure.ac
 	sh autogen.sh
 	./configure
-	make
+	make -j $(getconf _NPROCESSORS_ONLN)
 	make install
 	ldconfig
 fi
@@ -140,7 +140,7 @@ sed -i /usr/src/freeswitch/modules.conf -e s:'endpoints/mod_verto:#endpoints/mod
 --with-openssl --enable-core-pgsql-support
 
 # compile and install
-make
+make -j $(getconf _NPROCESSORS_ONLN)
 make install
 
 #return to the executing directory


### PR DESCRIPTION
While SignalWire doesn't have aarch64 debs of FreeSWITCH, PostgreSQL.org and sury.org have debs of PgSQL & PHP for aarch64, respectively. Compiling FreeSWITCH from source works cleanly on aarch64, tested on both Armbian and stock Debian. So might as well remove the unsupported, unless there's another reason to not?

While we're add it, let's parallelize the makes, as it's dreadfully slow on most SBCs without it