### PR TITLE
Improve apt key security and always install sngrep from official

### DIFF
--- a/debian/resources/php.sh
+++ b/debian/resources/php.sh
@@ -39,41 +39,41 @@ else
 	apt-get -y install apt-transport-https lsb-release ca-certificates
 
 	if [ ."$os_codename" = ."jessie" ]; then
-		wget -O /etc/apt/trusted.gpg.d/php.gpg https://packages.sury.org/php/apt.gpg
-		sh -c 'echo "deb https://packages.sury.org/php/ $(lsb_release -sc) main" > /etc/apt/sources.list.d/php.list'
+		wget -O /etc/apt/keyrings/php.gpg https://packages.sury.org/php/apt.gpg
+		sh -c 'echo "deb [signed-by=/etc/apt/keyrings/php.gpg] https://packages.sury.org/php/ $(lsb_release -sc) main" > /etc/apt/sources.list.d/php.list'
 	fi
 	if [ ."$os_codename" = ."stretch" ]; then
-		wget -O /etc/apt/trusted.gpg.d/php.gpg https://packages.sury.org/php/apt.gpg
-		sh -c 'echo "deb https://packages.sury.org/php/ $(lsb_release -sc) main" > /etc/apt/sources.list.d/php.list'
+		wget -O /etc/apt/keyrings/php.gpg https://packages.sury.org/php/apt.gpg
+		sh -c 'echo "deb [signed-by=/etc/apt/keyrings/php.gpg] https://packages.sury.org/php/ $(lsb_release -sc) main" > /etc/apt/sources.list.d/php.list'
 	fi
 	if [ ."$os_codename" = ."buster" ]; then
-		wget -O /etc/apt/trusted.gpg.d/php.gpg https://packages.sury.org/php/apt.gpg
+		wget -O /etc/apt/keyrings/php.gpg https://packages.sury.org/php/apt.gpg
 		sh -c 'echo "deb https://packages.sury.org/php/ $(lsb_release -sc) main" > /etc/apt/sources.list.d/php.list'
 	fi
 	if [ ."$os_codename" = ."bullseye" ]; then
 		if [ ."$php_version" = ."8.1" ]; then
 			/usr/bin/apt -y install apt-transport-https lsb-release ca-certificates curl wget gnupg2
-			/usr/bin/wget -qO- https://packages.sury.org/php/apt.gpg | gpg --dearmor > /etc/apt/trusted.gpg.d/sury-php-8.x.gpg
-			/usr/bin/sh -c 'echo "deb https://packages.sury.org/php/ $(lsb_release -sc) main" > /etc/apt/sources.list.d/php.list'
+			/usr/bin/wget -qO- https://packages.sury.org/php/apt.gpg | gpg --dearmor > /etc/apt/keyrings/sury-php-8.x.gpg
+			/usr/bin/sh -c 'echo "deb [signed-by=/etc/apt/keyrings/php.gpg] https://packages.sury.org/php/ $(lsb_release -sc) main" > /etc/apt/sources.list.d/php.list'
 		fi
 		if [ ."$php_version" = ."8.2" ]; then
 			/usr/bin/apt -y install apt-transport-https lsb-release ca-certificates curl wget gnupg2
-			/usr/bin/wget -qO- https://packages.sury.org/php/apt.gpg | gpg --dearmor > /etc/apt/trusted.gpg.d/sury-php-8.x.gpg
-			/usr/bin/sh -c 'echo "deb https://packages.sury.org/php/ $(lsb_release -sc) main" > /etc/apt/sources.list.d/php.list'
+			/usr/bin/wget -qO- https://packages.sury.org/php/apt.gpg | gpg --dearmor > /etc/apt/keyrings/sury-php-8.x.gpg
+			/usr/bin/sh -c 'echo "deb [signed-by=/etc/apt/keyrings/php.gpg] https://packages.sury.org/php/ $(lsb_release -sc) main" > /etc/apt/sources.list.d/php.list'
 		fi
 	fi
  	if [ ."$os_codename" = ."bookworm" ]; then
 		if [ ."$php_version" = ."8.1" ]; then
 			/usr/bin/apt -y install apt-transport-https lsb-release ca-certificates curl wget gnupg2
-			/usr/bin/wget -qO- https://packages.sury.org/php/apt.gpg | gpg --dearmor > /etc/apt/trusted.gpg.d/sury-php-8.x.gpg
-   			/usr/bin/chmod 644 /etc/apt/trusted.gpg.d/sury-php-8.x.gpg
-			/usr/bin/sh -c 'echo "deb https://packages.sury.org/php/ $(lsb_release -sc) main" > /etc/apt/sources.list.d/php.list'
+			/usr/bin/wget -qO- https://packages.sury.org/php/apt.gpg | gpg --dearmor > /etc/apt/keyrings/sury-php-8.x.gpg
+   			/usr/bin/chmod 644 /etc/apt/keyrings/sury-php-8.x.gpg
+			/usr/bin/sh -c 'echo "deb [signed-by=/etc/apt/keyrings/php.gpg] https://packages.sury.org/php/ $(lsb_release -sc) main" > /etc/apt/sources.list.d/php.list'
 		fi
 		if [ ."$php_version" = ."8.2" ]; then
 			/usr/bin/apt -y install apt-transport-https lsb-release ca-certificates curl wget gnupg2
-			/usr/bin/wget -qO- https://packages.sury.org/php/apt.gpg | gpg --dearmor > /etc/apt/trusted.gpg.d/sury-php-8.x.gpg
-   			/usr/bin/chmod 644 /etc/apt/trusted.gpg.d/sury-php-8.x.gpg
-			/usr/bin/sh -c 'echo "deb https://packages.sury.org/php/ $(lsb_release -sc) main" > /etc/apt/sources.list.d/php.list'
+			/usr/bin/wget -qO- https://packages.sury.org/php/apt.gpg | gpg --dearmor > /etc/apt/keyrings/sury-php-8.x.gpg
+   			/usr/bin/chmod 644 /etc/apt/keyrings/sury-php-8.x.gpg
+			/usr/bin/sh -c 'echo "deb [signed-by=/etc/apt/keyrings/php.gpg] https://packages.sury.org/php/ $(lsb_release -sc) main" > /etc/apt/sources.list.d/php.list'
 		fi
 	fi
 fi

--- a/debian/resources/php.sh
+++ b/debian/resources/php.sh
@@ -39,15 +39,15 @@ else
 	apt-get -y install apt-transport-https lsb-release ca-certificates
 
 	if [ ."$os_codename" = ."jessie" ]; then
-		wget -O /etc/apt/keyrings/php.gpg https://packages.sury.org/php/apt.gpg
+		wget -O - https://packages.sury.org/php/apt.gpg | gpg --dearmor -o /etc/apt/keyrings/php.gpg
 		sh -c 'echo "deb [signed-by=/etc/apt/keyrings/php.gpg] https://packages.sury.org/php/ $(lsb_release -sc) main" > /etc/apt/sources.list.d/php.list'
 	fi
 	if [ ."$os_codename" = ."stretch" ]; then
-		wget -O /etc/apt/keyrings/php.gpg https://packages.sury.org/php/apt.gpg
+		wget -O - https://packages.sury.org/php/apt.gpg | gpg --dearmor -o /etc/apt/keyrings/php.gpg
 		sh -c 'echo "deb [signed-by=/etc/apt/keyrings/php.gpg] https://packages.sury.org/php/ $(lsb_release -sc) main" > /etc/apt/sources.list.d/php.list'
 	fi
 	if [ ."$os_codename" = ."buster" ]; then
-		wget -O /etc/apt/keyrings/php.gpg https://packages.sury.org/php/apt.gpg
+		wget -O - https://packages.sury.org/php/apt.gpg | gpg --dearmor -o /etc/apt/keyrings/php.gpg
 		sh -c 'echo "deb https://packages.sury.org/php/ $(lsb_release -sc) main" > /etc/apt/sources.list.d/php.list'
 	fi
 	if [ ."$os_codename" = ."bullseye" ]; then
@@ -67,13 +67,13 @@ else
 			/usr/bin/apt -y install apt-transport-https lsb-release ca-certificates curl wget gnupg2
 			/usr/bin/wget -qO- https://packages.sury.org/php/apt.gpg | gpg --dearmor > /etc/apt/keyrings/sury-php-8.x.gpg
    			/usr/bin/chmod 644 /etc/apt/keyrings/sury-php-8.x.gpg
-			/usr/bin/sh -c 'echo "deb [signed-by=/etc/apt/keyrings/php.gpg] https://packages.sury.org/php/ $(lsb_release -sc) main" > /etc/apt/sources.list.d/php.list'
+			/usr/bin/sh -c 'echo "deb [signed-by=/etc/apt/keyrings/sury-php-8.x.gpg] https://packages.sury.org/php/ $(lsb_release -sc) main" > /etc/apt/sources.list.d/php.list'
 		fi
 		if [ ."$php_version" = ."8.2" ]; then
 			/usr/bin/apt -y install apt-transport-https lsb-release ca-certificates curl wget gnupg2
 			/usr/bin/wget -qO- https://packages.sury.org/php/apt.gpg | gpg --dearmor > /etc/apt/keyrings/sury-php-8.x.gpg
    			/usr/bin/chmod 644 /etc/apt/keyrings/sury-php-8.x.gpg
-			/usr/bin/sh -c 'echo "deb [signed-by=/etc/apt/keyrings/php.gpg] https://packages.sury.org/php/ $(lsb_release -sc) main" > /etc/apt/sources.list.d/php.list'
+			/usr/bin/sh -c 'echo "deb [signed-by=/etc/apt/keyrings/sury-php-8.x.gpg] https://packages.sury.org/php/ $(lsb_release -sc) main" > /etc/apt/sources.list.d/php.list'
 		fi
 	fi
 fi

--- a/debian/resources/postgresql.sh
+++ b/debian/resources/postgresql.sh
@@ -28,9 +28,9 @@ fi
 
 #postgres official repository
 if [ ."$database_repo" = ."official" ]; then
-	sh -c 'echo "deb [signed-by=/etc/apt/trusted.gpg.d/pgdg.gpg] http://apt.postgresql.org/pub/repos/apt $(lsb_release -cs)-pgdg main" > /etc/apt/sources.list.d/pgdg.list'
-	wget --quiet -O - https://www.postgresql.org/media/keys/ACCC4CF8.asc | gpg --dearmor -o /etc/apt/trusted.gpg.d/pgdg.gpg
-	chmod 644 /etc/apt/trusted.gpg.d/pgdg.gpg
+	sh -c 'echo "deb [signed-by=/etc/apt/keyrings/pgdg.gpg] http://apt.postgresql.org/pub/repos/apt $(lsb_release -cs)-pgdg main" > /etc/apt/sources.list.d/pgdg.list'
+	wget --quiet -O - https://www.postgresql.org/media/keys/ACCC4CF8.asc | gpg --dearmor -o /etc/apt/keyrings/pgdg.gpg
+	chmod 644 /etc/apt/keyrings/pgdg.gpg
 	apt-get update && apt-get upgrade -y
 	if [ ."$database_host" = ."127.0.0.1" ] || [ ."$database_host" = ."::1" ] ; then
 		if [ ."$database_version" = ."latest" ]; then

--- a/debian/resources/sngrep.sh
+++ b/debian/resources/sngrep.sh
@@ -18,10 +18,8 @@ if [ ."$cpu_architecture" = ."arm" ]; then
 	cd /usr/src/sngrep && make install
 else
 	#package install
-	if [ ."$os_codename" = ."jessie" ]; then
-		echo "deb http://packages.irontec.com/debian $os_codename main" > /etc/apt/sources.list.d/sngrep.list
-		wget http://packages.irontec.com/public.key -q -O - | apt-key add -
-	fi
+	echo "deb [signed-by=/etc/apt/keyrings/irontec.gpg] http://packages.irontec.com/debian $os_codename main" > /etc/apt/sources.list.d/sngrep.list
+	wget http://packages.irontec.com/public.key -q -O - | gpg --dearmor -o /etc/apt/keyrings/irontec.gpg
 	apt-get update
 	apt-get install -y sngrep
 fi

--- a/debian/resources/switch/package-release.sh
+++ b/debian/resources/switch/package-release.sh
@@ -19,10 +19,10 @@ if [ ."$cpu_architecture" = ."x86" ]; then
 	echo "deb-src [signed-by=/usr/share/keyrings/signalwire-freeswitch-repo.gpg] https://freeswitch.signalwire.com/repo/deb/debian-release/ `lsb_release -sc` main" >> /etc/apt/sources.list.d/freeswitch.list
 fi
 if [ ."$cpu_architecture" = ."arm" ]; then
-	wget --http-user=signalwire --http-password=$switch_token -O - https://freeswitch.signalwire.com/repo/deb/rpi/debian-release/freeswitch_archive_g0.pub | apt-key add -
+	wget --http-user=signalwire --http-password=$switch_token -O /usr/share/keyrings/signalwire-freeswitch-repo.gpg https://freeswitch.signalwire.com/repo/deb/rpi/debian-release/freeswitch_archive_g0.pub
 	echo "machine freeswitch.signalwire.com login signalwire password $switch_token" > /etc/apt/auth.conf
-	echo "deb https://freeswitch.signalwire.com/repo/deb/rpi/debian-release/ `lsb_release -sc` main" > /etc/apt/sources.list.d/freeswitch.list
-	echo "deb-src https://freeswitch.signalwire.com/repo/deb/rpi/debian-release/ `lsb_release -sc` main" >> /etc/apt/sources.list.d/freeswitch.list
+	echo "deb [signed-by=/etc/apt/keyrings/signalwire-freeswitch-repo.gpg] https://freeswitch.signalwire.com/repo/deb/rpi/debian-release/ `lsb_release -sc` main" > /etc/apt/sources.list.d/freeswitch.list
+	echo "deb-src [signed-by=/etc/apt/keyrings/signalwire-freeswitch-repo.gpg] https://freeswitch.signalwire.com/repo/deb/rpi/debian-release/ `lsb_release -sc` main" >> /etc/apt/sources.list.d/freeswitch.list
 fi
 
 apt-get update

--- a/debian/resources/switch/repo.sh
+++ b/debian/resources/switch/repo.sh
@@ -19,7 +19,7 @@ if [ ."$cpu_architecture" = ."x86" ]; then
 	echo "deb-src [signed-by=/usr/share/keyrings/signalwire-freeswitch-repo.gpg] https://freeswitch.signalwire.com/repo/deb/debian-release/ `lsb_release -sc` main" >> /etc/apt/sources.list.d/freeswitch.list
 fi
 if [ ."$cpu_architecture" = ."arm" ]; then
-	wget -O - https://files.freeswitch.org/repo/deb/rpi/debian-release/freeswitch_archive_g0.pub | apt-key add -
-	echo "deb http://files.freeswitch.org/repo/deb/rpi/debian-release/ `lsb_release -sc` main" > /etc/apt/sources.list.d/freeswitch.list
-	echo "deb-src http://files.freeswitch.org/repo/deb/rpi/debian-release/ `lsb_release -sc` main" >> /etc/apt/sources.list.d/freeswitch.list
+	wget --http-user=signalwire --http-password=$switch_token -O /usr/share/keyrings/signalwire-freeswitch-repo.gpg https://files.freeswitch.org/repo/deb/rpi/debian-release/freeswitch_archive_g0.pub
+	echo "deb [signed-by=/usr/share/keyrings/signalwire-freeswitch-repo.gpg] http://files.freeswitch.org/repo/deb/rpi/debian-release/ `lsb_release -sc` main" > /etc/apt/sources.list.d/freeswitch.list
+	echo "deb-src [signed-by=/usr/share/keyrings/signalwire-freeswitch-repo.gpg] http://files.freeswitch.org/repo/deb/rpi/debian-release/ `lsb_release -sc` main" >> /etc/apt/sources.list.d/freeswitch.list
 fi

--- a/debian/resources/upgrade/php.sh
+++ b/debian/resources/upgrade/php.sh
@@ -34,8 +34,8 @@ cd "$(dirname "$0")"
 if [ ."$php_version" = ."8.2" ]; then
 	#add a repo for php 8.x
 	/usr/bin/apt -y install apt-transport-https lsb-release ca-certificates curl wget gnupg2
-	/usr/bin/wget -qO- https://packages.sury.org/php/apt.gpg | gpg --dearmor > /etc/apt/trusted.gpg.d/sury-php-8.x.gpg
-	/usr/bin/sh -c 'echo "deb https://packages.sury.org/php/ $(lsb_release -sc) main" > /etc/apt/sources.list.d/php.list'
+	/usr/bin/wget -qO- https://packages.sury.org/php/apt.gpg | gpg --dearmor > /etc/apt/keyrings/sury-php-8.x.gpg
+	/usr/bin/sh -c 'echo "deb [signed-by=/etc/apt/keyrings/php.gpg] https://packages.sury.org/php/ $(lsb_release -sc) main" > /etc/apt/sources.list.d/php.list'
 	/usr/bin/apt-get update
 
 	#install php 8.2
@@ -50,8 +50,8 @@ fi
 if [ ."$php_version" = ."8.1" ]; then
 	#add a repo for php 7.x
 	/usr/bin/apt -y install apt-transport-https lsb-release ca-certificates curl wget gnupg2
-	/usr/bin/wget -qO- https://packages.sury.org/php/apt.gpg | gpg --dearmor > /etc/apt/trusted.gpg.d/sury-php-8.x.gpg
-	/usr/bin/sh -c 'echo "deb https://packages.sury.org/php/ $(lsb_release -sc) main" > /etc/apt/sources.list.d/php.list'
+	/usr/bin/wget -qO- https://packages.sury.org/php/apt.gpg | gpg --dearmor > /etc/apt/keyrings/sury-php-8.x.gpg
+	/usr/bin/sh -c 'echo "deb [signed-by=/etc/apt/keyrings/php.gpg] https://packages.sury.org/php/ $(lsb_release -sc) main" > /etc/apt/sources.list.d/php.list'
 	/usr/bin/apt-get update
 
 	#install php 8.1

--- a/devuan/resources/switch/package-release.sh
+++ b/devuan/resources/switch/package-release.sh
@@ -19,10 +19,10 @@ if [ ."$cpu_architecture" = ."x86" ]; then
 	echo "deb-src [signed-by=/usr/share/keyrings/signalwire-freeswitch-repo.gpg] https://freeswitch.signalwire.com/repo/deb/debian-release/ ${os_codename_debian} main" >> /etc/apt/sources.list.d/freeswitch.list
 fi
 if [ ."$cpu_architecture" = ."arm" ]; then
-	wget --http-user=signalwire --http-password=$switch_token -O - https://freeswitch.signalwire.com/repo/deb/rpi/debian-release/freeswitch_archive_g0.pub | apt-key add -
+	wget --http-user=signalwire --http-password=$switch_token -O /usr/share/keyrings/signalwire-freeswitch-repo.gpg https://freeswitch.signalwire.com/repo/deb/rpi/debian-release/freeswitch_archive_g0.pub
 	echo "machine freeswitch.signalwire.com login signalwire password $switch_token" > /etc/apt/auth.conf
-	echo "deb https://freeswitch.signalwire.com/repo/deb/rpi/debian-release/ ${os_codename_debian} main" > /etc/apt/sources.list.d/freeswitch.list
-	echo "deb-src https://freeswitch.signalwire.com/repo/deb/rpi/debian-release/ ${os_codename_debian} main" >> /etc/apt/sources.list.d/freeswitch.list
+	echo "deb [signed-by=/usr/share/keyrings/signalwire-freeswitch-repo.gpg] https://freeswitch.signalwire.com/repo/deb/rpi/debian-release/ ${os_codename_debian} main" > /etc/apt/sources.list.d/freeswitch.list
+	echo "deb-src [signed-by=/usr/share/keyrings/signalwire-freeswitch-repo.gpg] https://freeswitch.signalwire.com/repo/deb/rpi/debian-release/ ${os_codename_debian} main" >> /etc/apt/sources.list.d/freeswitch.list
 fi
 
 apt-get update

--- a/ubuntu/resources/postgresql.sh
+++ b/ubuntu/resources/postgresql.sh
@@ -24,8 +24,8 @@ fi
 
 #postgres official repository
 if [ ."$database_repo" = ."official" ]; then
-	sh -c 'echo "deb [signed-by=/etc/apt/trusted.gpg.d/pgdg.gpg] http://apt.postgresql.org/pub/repos/apt $(lsb_release -cs)-pgdg main" > /etc/apt/sources.list.d/pgdg.list'
-	wget --quiet -O - https://www.postgresql.org/media/keys/ACCC4CF8.asc | gpg --dearmor -o /etc/apt/trusted.gpg.d/pgdg.gpg
+	sh -c 'echo "deb [signed-by=/etc/apt/keyrings/pgdg.gpg] http://apt.postgresql.org/pub/repos/apt $(lsb_release -cs)-pgdg main" > /etc/apt/sources.list.d/pgdg.list'
+	wget --quiet -O - https://www.postgresql.org/media/keys/ACCC4CF8.asc | gpg --dearmor -o /etc/apt/keyrings/pgdg.gpg
 	apt-get update && apt-get upgrade -y
 	if [ ."$database_host" = ."127.0.0.1" ] || [ ."$database_host" = ."::1" ] ; then
 		if [ ."$database_version" = ."latest" ]; then


### PR DESCRIPTION
Adding key files to `/etc/apt/trusted.gpg.d/` is equivalent to the old method of apt-key add that appended to `/etc/apt/trusted.gpg` because while each key is an individual file for easier delete/add, the entire folder is trusted for any repository. Putting the keys into the `/etc/apt/keyrings/` folder as suggested by the documentation forces us to add the specific key to the deb entries instead of all keys being trusted automatically from the other folder. I did not make this change for older/unused/rarely used scripts, like the ones that don't even have the new signalwire access token updates.

I've also enabled to install sngrep from the official repository always instead of just on Jessie because debian is always significantly behind on the sngrep versions to the point where a major bug that was clipping characters on the sides of the packet displays was present in fairly new versions of debian. Particularly caused me issues when trying to copy/paste the stir/shaken headers because those missing characters would make it impossible to decode the JWT when copy/pasting.