### PR TITLE
Updated for Ubuntu Jammy compatibility..

### DIFF
--- a/ubuntu/resources/config.sh
+++ b/ubuntu/resources/config.sh
@@ -26,5 +26,5 @@ database_port=5432              # port number
 database_backup=false           # true or false
 
 # General Settings
-php_version=7.4                 # PHP version 5.6 or 7.0, 7.1, 7.2
+php_version=8.1                 # PHP version 5.6 or 7.0, 7.1, 7.2, 8.1
 letsencrypt_folder=true         # true or false

--- a/ubuntu/resources/ioncube.sh
+++ b/ubuntu/resources/ioncube.sh
@@ -92,3 +92,14 @@ if [ ."$php_version" = ."7.4" ]; then
         #restart the service
         service php7.4-fpm restart
 fi
+if [ ."$php_version" = ."8.1" ]; then
+        #copy the php extension .so into the php lib directory
+        cp ioncube/ioncube_loader_lin_8.1.so /usr/lib/php/20210902
+
+        #add the 00-ioncube.ini file
+        echo "zend_extension = /usr/lib/php/20210902/ioncube_loader_lin_8.1.so" > /etc/php/8.1/fpm/conf.d/00-ioncube.ini
+        echo "zend_extension = /usr/lib/php/20210902/ioncube_loader_lin_8.1.so" > /etc/php/8.1/cli/conf.d/00-ioncube.ini
+
+        #restart the service
+        service php8.1-fpm restart
+fi

--- a/ubuntu/resources/nginx.sh
+++ b/ubuntu/resources/nginx.sh
@@ -15,7 +15,9 @@ verbose "Installing the web server"
 if [ ."$cpu_architecture" = ."arm" ]; then
 	#Pi2 and Pi3 Raspbian
 	#Odroid
-	if [ ."$os_codename" = ."focal" ]; then
+	if [ ."$os_codename" = ."jammy" ]; then
+	      php_version=8.1
+	elif [ ."$os_codename" = ."focal" ]; then
 	      php_version=7.4
 	else
 	      php_version=5.6
@@ -40,6 +42,9 @@ if [ ."$php_version" = ."7.2" ]; then
 fi
 if [ ."$php_version" = ."7.4" ]; then
         sed -i /etc/nginx/sites-available/fusionpbx -e 's#unix:.*;#unix:/var/run/php/php7.4-fpm.sock;#g'
+fi
+if [ ."$php_version" = ."8.1" ]; then
+        sed -i /etc/nginx/sites-available/fusionpbx -e 's#unix:.*;#unix:/var/run/php/php8.1-fpm.sock;#g'
 fi
 ln -s /etc/nginx/sites-available/fusionpbx /etc/nginx/sites-enabled/fusionpbx
 

--- a/ubuntu/resources/php.sh
+++ b/ubuntu/resources/php.sh
@@ -13,6 +13,11 @@ verbose "Configuring PHP"
 
 #add the repository
 if [ ."$os_name" = ."Ubuntu" ]; then
+	#22.04.x - /*jammy/
+        if [ ."$os_codename" = ."jammy" ]; then
+                echo "Ubuntu 22.04 LTS\n"
+                php_version=8.1
+        fi
 	#20.04.x - /*bionic/
         if [ ."$os_codename" = ."focal" ]; then
                 echo "Ubuntu 20.04 LTS\n"
@@ -53,6 +58,9 @@ fi
 if [ ."$php_version" = ."7.4" ]; then
         apt-get install -y php7.4 php7.4-cli php7.4-fpm php7.4-pgsql php7.4-sqlite3 php7.4-odbc php7.4-curl php7.4-imap php7.4-xml php7.4-gd php7.4-mbstring
 fi
+if [ ."$php_version" = ."8.1" ]; then
+        apt-get install -y php8.1 php8.1-cli php8.1-fpm php8.1-pgsql php8.1-sqlite3 php8.1-odbc php8.1-curl php8.1-imap php8.1-xml php8.1-gd php8.1-mbstring
+fi
 
 #update config if source is being used
 if [ ."$php_version" = ."5" ]; then
@@ -74,6 +82,10 @@ fi
 if [ ."$php_version" = ."7.4" ]; then
         verbose "version 7.4"
         php_ini_file='/etc/php/7.4/fpm/php.ini'
+fi
+if [ ."$php_version" = ."8.1" ]; then
+        verbose "version 8.1"
+        php_ini_file='/etc/php/8.1/fpm/php.ini'
 fi
 sed 's#post_max_size = .*#post_max_size = 80M#g' -i $php_ini_file
 sed 's#upload_max_filesize = .*#upload_max_filesize = 80M#g' -i $php_ini_file
@@ -101,6 +113,9 @@ if [ ."$php_version" = ."7.2" ]; then
 fi
 if [ ."$php_version" = ."7.4" ]; then
         systemctl restart php7.4-fpm
+fi
+if [ ."$php_version" = ."8.1" ]; then
+        systemctl restart php8.1-fpm
 fi
 #init.d
 #/usr/sbin/service php5-fpm restart


### PR DESCRIPTION
Updated installer resource scripts for Ubuntu Jammy and PHP version 8.1

The following were updated to install on Ubuntu Jammy 22.04 LTS.
ubuntu/resources/nginx.sh
ubuntu/resources/php.sh
ubuntu/resources/iocube.sh
ubuntu/resources/config.sh

The updated entries check for the 'Jammy' release and set the PHP version to 8.1, as well as update the path destinations to account for the updated PHP version.