### PR TITLE
Install Cron on Debian

### DIFF
--- a/debian/resources/finish.sh
+++ b/debian/resources/finish.sh
@@ -111,6 +111,7 @@ cp /var/www/fusionpbx/app/event_guard/resources/service/debian.service /etc/syst
 /bin/systemctl daemon-reload
 
 #add xml cdr import to crontab
+apt install cron
 (crontab -l; echo "* * * * * $(which php) /var/www/fusionpbx/app/xml_cdr/xml_cdr_import.php 300") | crontab
 
 #welcome message


### PR DESCRIPTION
Debian 12 doesn't always have crontab command available by default