### PR TITLE
Added needed Snom rewrite rules to all distros

### DIFF
--- a/centos/resources/nginx/fusionpbx
+++ b/centos/resources/nginx/fusionpbx
@@ -105,6 +105,11 @@ server {
 	rewrite "^.*/provision/([A-Fa-f0-9]{12})-contacts\.cfg$" "/app/provision/?mac=$1&file={%24mac}-contacts.cfg";
 	rewrite "^.*/provision/([A-Fa-f0-9]{12})-smartblf\.cfg$" "/app/provision/?mac=$1&file={%24mac}-smartblf.cfg";
 
+	#Snom
+	rewrite "^.*/provision/-([A-Fa-f0-9]{12})?$" /app/provision/index.php?mac=$1;
+	rewrite "^.*/provision/C520-WiMi_([A-Fa-f0-9]{12})\.cfg$" /app/provision/index.php?mac=$1;
+    rewrite "^.*/provision/([A-Fa-f0-9]{12})/directory\.xml$" /app/provision/?mac=$1&file=directory.xml;
+
 	access_log /var/log/nginx/access.log;
 	error_log /var/log/nginx/error.log;
 
@@ -210,6 +215,11 @@ server {
 	#Digium
 	rewrite "^.*/provision/([A-Fa-f0-9]{12})-contacts\.cfg$" "/app/provision/?mac=$1&file={%24mac}-contacts.cfg";
 	rewrite "^.*/provision/([A-Fa-f0-9]{12})-smartblf\.cfg$" "/app/provision/?mac=$1&file={%24mac}-smartblf.cfg";
+
+	#Snom
+	rewrite "^.*/provision/-([A-Fa-f0-9]{12})?$" /app/provision/index.php?mac=$1;
+	rewrite "^.*/provision/C520-WiMi_([A-Fa-f0-9]{12})\.cfg$" /app/provision/index.php?mac=$1;
+    rewrite "^.*/provision/([A-Fa-f0-9]{12})/directory\.xml$" /app/provision/?mac=$1&file=directory.xml;
 
 	access_log /var/log/nginx/access.log;
 	error_log /var/log/nginx/error.log;

--- a/debian/resources/nginx/fusionpbx
+++ b/debian/resources/nginx/fusionpbx
@@ -130,6 +130,8 @@ server {
 
 	#Snom
 	rewrite "^.*/provision/-([A-Fa-f0-9]{12})?$" /app/provision/index.php?mac=$1;
+    rewrite "^.*/provision/C520-WiMi_([A-Fa-f0-9]{12})\.cfg$" /app/provision/index.php?mac=$1;
+    rewrite "^.*/provision/([A-Fa-f0-9]{12})/directory\.xml$" /app/provision/?mac=$1&file=directory.xml;
 
 	access_log /var/log/nginx/access.log;
 	error_log /var/log/nginx/error.log;
@@ -265,6 +267,11 @@ server {
 	#Digium
 	rewrite "^.*/provision/([A-Fa-f0-9]{12})-contacts\.cfg$" "/app/provision/?mac=$1&file={%24mac}-contacts.cfg";
 	rewrite "^.*/provision/([A-Fa-f0-9]{12})-smartblf\.cfg$" "/app/provision/?mac=$1&file={%24mac}-smartblf.cfg";
+
+	#Snom
+	rewrite "^.*/provision/-([A-Fa-f0-9]{12})?$" /app/provision/index.php?mac=$1;
+	rewrite "^.*/provision/C520-WiMi_([A-Fa-f0-9]{12})\.cfg$" /app/provision/index.php?mac=$1;
+    rewrite "^.*/provision/([A-Fa-f0-9]{12})/directory\.xml$" /app/provision/?mac=$1&file=directory.xml;
 
 	access_log /var/log/nginx/access.log;
 	error_log /var/log/nginx/error.log;

--- a/devuan/resources/nginx/fusionpbx
+++ b/devuan/resources/nginx/fusionpbx
@@ -124,6 +124,8 @@ server {
 
 	#Snom
 	rewrite "^.*/provision/-([A-Fa-f0-9]{12})?$" /app/provision/index.php?mac=$1;
+	rewrite "^.*/provision/C520-WiMi_([A-Fa-f0-9]{12})\.cfg$" /app/provision/index.php?mac=$1;
+    rewrite "^.*/provision/([A-Fa-f0-9]{12})/directory\.xml$" /app/provision/?mac=$1&file=directory.xml;
 
 	access_log /var/log/nginx/access.log;
 	error_log /var/log/nginx/error.log;
@@ -251,6 +253,11 @@ server {
 	#Digium
 	rewrite "^.*/provision/([A-Fa-f0-9]{12})-contacts\.cfg$" "/app/provision/?mac=$1&file={%24mac}-contacts.cfg";
 	rewrite "^.*/provision/([A-Fa-f0-9]{12})-smartblf\.cfg$" "/app/provision/?mac=$1&file={%24mac}-smartblf.cfg";
+
+	#Snom
+	rewrite "^.*/provision/-([A-Fa-f0-9]{12})?$" /app/provision/index.php?mac=$1;
+	rewrite "^.*/provision/C520-WiMi_([A-Fa-f0-9]{12})\.cfg$" /app/provision/index.php?mac=$1;
+    rewrite "^.*/provision/([A-Fa-f0-9]{12})/directory\.xml$" /app/provision/?mac=$1&file=directory.xml;
 
 	access_log /var/log/nginx/access.log;
 	error_log /var/log/nginx/error.log;

--- a/freebsd/resources/nginx/fusionpbx.conf
+++ b/freebsd/resources/nginx/fusionpbx.conf
@@ -129,6 +129,11 @@ server {
 	rewrite "^.*/provision/([A-Fa-f0-9]{12})-contacts\.cfg$" "/app/provision/?mac=$1&file={%24mac}-contacts.cfg";
 	rewrite "^.*/provision/([A-Fa-f0-9]{12})-smartblf\.cfg$" "/app/provision/?mac=$1&file={%24mac}-smartblf.cfg";
 
+	#Snom
+	rewrite "^.*/provision/-([A-Fa-f0-9]{12})?$" /app/provision/index.php?mac=$1;
+	rewrite "^.*/provision/C520-WiMi_([A-Fa-f0-9]{12})\.cfg$" /app/provision/index.php?mac=$1;
+    rewrite "^.*/provision/([A-Fa-f0-9]{12})/directory\.xml$" /app/provision/?mac=$1&file=directory.xml;
+
 	#nginx settings
 	client_max_body_size 128M;
 	client_body_buffer_size 128k;
@@ -252,6 +257,11 @@ server {
 	#digium
 	rewrite "^.*/provision/([A-Fa-f0-9]{12})-contacts\.cfg$" "/app/provision/?mac=$1&file={%24mac}-contacts.cfg";
 	rewrite "^.*/provision/([A-Fa-f0-9]{12})-smartblf\.cfg$" "/app/provision/?mac=$1&file={%24mac}-smartblf.cfg";
+
+	#Snom
+	rewrite "^.*/provision/-([A-Fa-f0-9]{12})?$" /app/provision/index.php?mac=$1;
+	rewrite "^.*/provision/C520-WiMi_([A-Fa-f0-9]{12})\.cfg$" /app/provision/index.php?mac=$1;
+    rewrite "^.*/provision/([A-Fa-f0-9]{12})/directory\.xml$" /app/provision/?mac=$1&file=directory.xml;
 
 	#nginx settings
 	client_max_body_size 128M;

--- a/ubuntu/resources/nginx/fusionpbx
+++ b/ubuntu/resources/nginx/fusionpbx
@@ -117,6 +117,11 @@ server {
 	rewrite "^.*/provision/VCS754_([A-Fa-f0-9]{12})\.cfg$" /app/provision/?mac=$1;
 	rewrite "^.*/provision/pb([A-Fa-f0-9-]{12,17})/directory\.xml$" /app/provision/?mac=$1&file=directory.xml;
 
+	#Snom
+	rewrite "^.*/provision/-([A-Fa-f0-9]{12})?$" /app/provision/index.php?mac=$1;
+	rewrite "^.*/provision/C520-WiMi_([A-Fa-f0-9]{12})\.cfg$" /app/provision/index.php?mac=$1;
+    rewrite "^.*/provision/([A-Fa-f0-9]{12})/directory\.xml$" /app/provision/?mac=$1&file=directory.xml;
+
 	access_log /var/log/nginx/access.log;
 	error_log /var/log/nginx/error.log;
 
@@ -228,6 +233,11 @@ server {
 	#Vtech
 	rewrite "^.*/provision/VCS754_([A-Fa-f0-9]{12})\.cfg$" /app/provision/?mac=$1;
 	rewrite "^.*/provision/pb([A-Fa-f0-9-]{12,17})/directory\.xml$" /app/provision/?mac=$1&file=directory.xml;
+
+	#Snom
+	rewrite "^.*/provision/-([A-Fa-f0-9]{12})?$" /app/provision/index.php?mac=$1;
+	rewrite "^.*/provision/C520-WiMi_([A-Fa-f0-9]{12})\.cfg$" /app/provision/index.php?mac=$1;
+    rewrite "^.*/provision/([A-Fa-f0-9]{12})/directory\.xml$" /app/provision/?mac=$1&file=directory.xml;
 
 	access_log /var/log/nginx/access.log;
 	error_log /var/log/nginx/error.log;


### PR DESCRIPTION
This PR adds all the Snom nginx rewrite rules to all distros to be more uniform.

This PR also adds the required rewrite rules for the [recently merged Snom C520 Template PR](https://github.com/fusionpbx/fusionpbx/pull/6980).

In the PR I mentioned that I would add the required rewrite rules if my changes had gotten merged. These are those rules.