### PR TITLE
Update iptables.sh for Debian 12

### DIFF
--- a/debian/resources/iptables.sh
+++ b/debian/resources/iptables.sh
@@ -22,6 +22,11 @@ if [ ."$os_codename" = ."bullseye" ]; then
 	update-alternatives --set iptables /usr/sbin/iptables-legacy
 	update-alternatives --set ip6tables /usr/sbin/ip6tables-legacy
 fi
+if [ ."$os_codename" = ."bookworm" ]; then
+	apt-get install -y iptables
+	update-alternatives --set iptables /usr/sbin/iptables-legacy
+	update-alternatives --set ip6tables /usr/sbin/ip6tables-legacy
+fi
 
 #remove ufw
 ufw reset


### PR DESCRIPTION
Bookworm (12) is not accounted for in the iptables script. End up with an almost blank chain on install.