### PR TITLE
Added nginx rewrites to fix snom provision url

### DIFF
--- a/centos/resources/nginx/fusionpbx
+++ b/centos/resources/nginx/fusionpbx
@@ -106,7 +106,7 @@ server {
 	rewrite "^.*/provision/([A-Fa-f0-9]{12})-smartblf\.cfg$" "/app/provision/?mac=$1&file={%24mac}-smartblf.cfg";
 
 	#Snom
-	rewrite "^.*/provision/-([A-Fa-f0-9]{12})?$" /app/provision/index.php?mac=$1;
+	rewrite "^.*/provision/.*-([A-Fa-f0-9]{12})\.?(cfg|htm)?$" /app/provision/index.php?mac=$1;
 	rewrite "^.*/provision/C520-WiMi_([A-Fa-f0-9]{12})\.cfg$" /app/provision/index.php?mac=$1;
     rewrite "^.*/provision/([A-Fa-f0-9]{12})/directory\.xml$" /app/provision/?mac=$1&file=directory.xml;
 
@@ -217,7 +217,7 @@ server {
 	rewrite "^.*/provision/([A-Fa-f0-9]{12})-smartblf\.cfg$" "/app/provision/?mac=$1&file={%24mac}-smartblf.cfg";
 
 	#Snom
-	rewrite "^.*/provision/-([A-Fa-f0-9]{12})?$" /app/provision/index.php?mac=$1;
+	rewrite "^.*/provision/.*-([A-Fa-f0-9]{12})\.?(cfg|htm)?$" /app/provision/index.php?mac=$1;
 	rewrite "^.*/provision/C520-WiMi_([A-Fa-f0-9]{12})\.cfg$" /app/provision/index.php?mac=$1;
     rewrite "^.*/provision/([A-Fa-f0-9]{12})/directory\.xml$" /app/provision/?mac=$1&file=directory.xml;
 

--- a/debian/resources/nginx/fusionpbx
+++ b/debian/resources/nginx/fusionpbx
@@ -129,7 +129,7 @@ server {
 	rewrite "^.*/provision/([A-Fa-f0-9]{12})-smartblf\.cfg$" "/app/provision/?mac=$1&file={%24mac}-smartblf.cfg";
 
 	#Snom
-	rewrite "^.*/provision/-([A-Fa-f0-9]{12})?$" /app/provision/index.php?mac=$1;
+	rewrite "^.*/provision/.*-([A-Fa-f0-9]{12})\.?(cfg|htm)?$" /app/provision/index.php?mac=$1;
     rewrite "^.*/provision/C520-WiMi_([A-Fa-f0-9]{12})\.cfg$" /app/provision/index.php?mac=$1;
     rewrite "^.*/provision/([A-Fa-f0-9]{12})/directory\.xml$" /app/provision/?mac=$1&file=directory.xml;
 
@@ -269,7 +269,7 @@ server {
 	rewrite "^.*/provision/([A-Fa-f0-9]{12})-smartblf\.cfg$" "/app/provision/?mac=$1&file={%24mac}-smartblf.cfg";
 
 	#Snom
-	rewrite "^.*/provision/-([A-Fa-f0-9]{12})?$" /app/provision/index.php?mac=$1;
+	rewrite "^.*/provision/.*-([A-Fa-f0-9]{12})\.?(cfg|htm)?$" /app/provision/index.php?mac=$1;
 	rewrite "^.*/provision/C520-WiMi_([A-Fa-f0-9]{12})\.cfg$" /app/provision/index.php?mac=$1;
     rewrite "^.*/provision/([A-Fa-f0-9]{12})/directory\.xml$" /app/provision/?mac=$1&file=directory.xml;
 

--- a/devuan/resources/nginx/fusionpbx
+++ b/devuan/resources/nginx/fusionpbx
@@ -123,7 +123,7 @@ server {
 	rewrite "^.*/provision/([A-Fa-f0-9]{12})-smartblf\.cfg$" "/app/provision/?mac=$1&file={%24mac}-smartblf.cfg";
 
 	#Snom
-	rewrite "^.*/provision/-([A-Fa-f0-9]{12})?$" /app/provision/index.php?mac=$1;
+	rewrite "^.*/provision/.*-([A-Fa-f0-9]{12})\.?(cfg|htm)?$" /app/provision/index.php?mac=$1;
 	rewrite "^.*/provision/C520-WiMi_([A-Fa-f0-9]{12})\.cfg$" /app/provision/index.php?mac=$1;
     rewrite "^.*/provision/([A-Fa-f0-9]{12})/directory\.xml$" /app/provision/?mac=$1&file=directory.xml;
 
@@ -255,7 +255,7 @@ server {
 	rewrite "^.*/provision/([A-Fa-f0-9]{12})-smartblf\.cfg$" "/app/provision/?mac=$1&file={%24mac}-smartblf.cfg";
 
 	#Snom
-	rewrite "^.*/provision/-([A-Fa-f0-9]{12})?$" /app/provision/index.php?mac=$1;
+	rewrite "^.*/provision/.*-([A-Fa-f0-9]{12})\.?(cfg|htm)?$" /app/provision/index.php?mac=$1;
 	rewrite "^.*/provision/C520-WiMi_([A-Fa-f0-9]{12})\.cfg$" /app/provision/index.php?mac=$1;
     rewrite "^.*/provision/([A-Fa-f0-9]{12})/directory\.xml$" /app/provision/?mac=$1&file=directory.xml;
 

--- a/freebsd/resources/nginx/fusionpbx.conf
+++ b/freebsd/resources/nginx/fusionpbx.conf
@@ -130,7 +130,7 @@ server {
 	rewrite "^.*/provision/([A-Fa-f0-9]{12})-smartblf\.cfg$" "/app/provision/?mac=$1&file={%24mac}-smartblf.cfg";
 
 	#Snom
-	rewrite "^.*/provision/-([A-Fa-f0-9]{12})?$" /app/provision/index.php?mac=$1;
+	rewrite "^.*/provision/.*-([A-Fa-f0-9]{12})\.?(cfg|htm)?$" /app/provision/index.php?mac=$1;
 	rewrite "^.*/provision/C520-WiMi_([A-Fa-f0-9]{12})\.cfg$" /app/provision/index.php?mac=$1;
     rewrite "^.*/provision/([A-Fa-f0-9]{12})/directory\.xml$" /app/provision/?mac=$1&file=directory.xml;
 
@@ -259,7 +259,7 @@ server {
 	rewrite "^.*/provision/([A-Fa-f0-9]{12})-smartblf\.cfg$" "/app/provision/?mac=$1&file={%24mac}-smartblf.cfg";
 
 	#Snom
-	rewrite "^.*/provision/-([A-Fa-f0-9]{12})?$" /app/provision/index.php?mac=$1;
+	rewrite "^.*/provision/.*-([A-Fa-f0-9]{12})\.?(cfg|htm)?$" /app/provision/index.php?mac=$1;
 	rewrite "^.*/provision/C520-WiMi_([A-Fa-f0-9]{12})\.cfg$" /app/provision/index.php?mac=$1;
     rewrite "^.*/provision/([A-Fa-f0-9]{12})/directory\.xml$" /app/provision/?mac=$1&file=directory.xml;
 

--- a/ubuntu/resources/nginx/fusionpbx
+++ b/ubuntu/resources/nginx/fusionpbx
@@ -118,7 +118,7 @@ server {
 	rewrite "^.*/provision/pb([A-Fa-f0-9-]{12,17})/directory\.xml$" /app/provision/?mac=$1&file=directory.xml;
 
 	#Snom
-	rewrite "^.*/provision/-([A-Fa-f0-9]{12})?$" /app/provision/index.php?mac=$1;
+	rewrite "^.*/provision/.*-([A-Fa-f0-9]{12})\.?(cfg|htm)?$" /app/provision/index.php?mac=$1;
 	rewrite "^.*/provision/C520-WiMi_([A-Fa-f0-9]{12})\.cfg$" /app/provision/index.php?mac=$1;
     rewrite "^.*/provision/([A-Fa-f0-9]{12})/directory\.xml$" /app/provision/?mac=$1&file=directory.xml;
 
@@ -235,7 +235,7 @@ server {
 	rewrite "^.*/provision/pb([A-Fa-f0-9-]{12,17})/directory\.xml$" /app/provision/?mac=$1&file=directory.xml;
 
 	#Snom
-	rewrite "^.*/provision/-([A-Fa-f0-9]{12})?$" /app/provision/index.php?mac=$1;
+	rewrite "^.*/provision/.*-([A-Fa-f0-9]{12})\.?(cfg|htm)?$" /app/provision/index.php?mac=$1;
 	rewrite "^.*/provision/C520-WiMi_([A-Fa-f0-9]{12})\.cfg$" /app/provision/index.php?mac=$1;
     rewrite "^.*/provision/([A-Fa-f0-9]{12})/directory\.xml$" /app/provision/?mac=$1&file=directory.xml;
 


### PR DESCRIPTION
These changes add the necessary rewrite rules for snom phones to follow the same url as other phone manufacturers.

Below are some sample screen snippets of my `access.log`

These changes make a slight modification to an existing rule.

![image](https://github.com/fusionpbx/fusionpbx-install.sh/assets/5287266/97ee22e8-f56c-4719-b7ab-3d8c3b80ac4c)

![image](https://github.com/fusionpbx/fusionpbx-install.sh/assets/5287266/3fa2d32b-da8e-40e4-8552-18eefe1f46de)
