### PR TITLE
v_xml_cdr_json changed from start_stamp to insert_date

### DIFF
--- a/debian/resources/backup/fusionpbx-maintenance
+++ b/debian/resources/backup/fusionpbx-maintenance
@@ -117,7 +117,7 @@ if [ .$purge_cdrs = .true ]; then
 	#call detail record - call flow
 	psql $db_name --port $db_port --host=$db_host --username=$db_username -c "delete from v_xml_cdr_flow WHERE insert_date < NOW() - INTERVAL '$days_keep_cdrs days'"
 	#call detail record - json
-	psql $db_name --port $db_port --host=$db_host --username=$db_username -c "delete from v_xml_cdr_json WHERE start_stamp < NOW() - INTERVAL '$days_keep_cdrs days'"
+	psql $db_name --port $db_port --host=$db_host --username=$db_username -c "delete from v_xml_cdr_json WHERE insert_date < NOW() - INTERVAL '$days_keep_cdrs days'"
 	#call detail record - call logs
 	psql $db_name --port $db_port --host=$db_host --username=$db_username -c "delete from v_xml_cdr_logs WHERE insert_date < NOW() - INTERVAL '$days_keep_cdrs days'"
 else


### PR DESCRIPTION
v_xml_cdr_json.start_stamp is always null so the old records in this table were not being purged. Changed to v_xml_cdr_json.insert_date since this field is populated