### PR TITLE
Create fail2ban.local

### DIFF
--- a/debian/resources/fail2ban/fail2ban.local
+++ b/debian/resources/fail2ban/fail2ban.local
@@ -1,0 +1,6 @@
+[DEFAULT]
+# Option: allowipv6
+# Notes.: Allows IPv6 interface:
+#       Default: auto
+# Values: [ auto yes (on, true, 1) no (off, false, 0) ] Default: auto
+allowipv6 = auto


### PR DESCRIPTION
adding this file removes the warning: 

WARNING 'allowipv6' not defined in 'Definition'. Using default one: 'auto'