### PR TITLE
pgpassword security and conflict avoidance

### DIFF
--- a/debian/resources/backup/fusionpbx-backup
+++ b/debian/resources/backup/fusionpbx-backup
@@ -25,3 +25,6 @@ pg_dump --verbose -Fc --host=$db_host --port=$db_port -U fusionpbx fusionpbx --s
 #tar -zvcf /var/backups/fusionpbx/backup_$now.tgz /var/backups/fusionpbx/postgresql/fusionpbx_pgsql_$now.sql /var/www/fusionpbx /usr/local/freeswitch/scripts /usr/local/freeswitch/storage /usr/local/freeswitch/recordings /etc/fusionpbx /usr/local/freeswitch/conf /usr/local/freeswitch/sounds/music/
 
 echo "Backup Completed"
+
+# pgpassword security and conflict avoidance
+unset PGPASSWORD

--- a/debian/resources/backup/fusionpbx-maintenance
+++ b/debian/resources/backup/fusionpbx-maintenance
@@ -175,3 +175,6 @@ fi
 
 #completed message
 echo "Maintenance Completed";
+
+# pgpassword security and conflict avoidance
+unset PGPASSWORD

--- a/debian/resources/finish.sh
+++ b/debian/resources/finish.sh
@@ -147,3 +147,6 @@ echo "      https://fusionpbx.com/support.php"
 echo "      https://www.fusionpbx.com"
 echo "      http://docs.fusionpbx.com"
 echo ""
+
+# pgpassword security and conflict avoidance
+unset PGPASSWORD

--- a/debian/resources/postgresql/dsn.sh
+++ b/debian/resources/postgresql/dsn.sh
@@ -68,3 +68,6 @@ done
 
 #restart freeswitch
 service freeswitch restart
+
+# pgpassword security and conflict avoidance
+unset PGPASSWORD

--- a/debian/resources/postgresql/empty.sh
+++ b/debian/resources/postgresql/empty.sh
@@ -25,3 +25,6 @@ pg_dump --verbose -Fc --host=$db_host --port=$db_port -U fusionpbx fusionpbx --s
 #empty the fusionpbx database
 sudo -u postgres psql -d fusionpbx -c "drop schema public cascade;";
 sudo -u postgres psql -d fusionpbx -c "create schema public;";
+
+# pgpassword security and conflict avoidance
+unset PGPASSWORD


### PR DESCRIPTION
remove the password from environment to reduce risk of exposure to other users and processes, and avoid possibly conflicting passwords