### PR TITLE
Enable package install for arm64

### DIFF
--- a/debian/pre-install.sh
+++ b/debian/pre-install.sh
@@ -7,7 +7,7 @@ apt-get update && apt-get upgrade -y
 apt-get install -y git lsb-release
 
 #get the install script
-cd /usr/src && git clone https://github.com/fusionpbx/fusionpbx-install.sh.git
+cd /usr/src && git clone https://codeberg.org/industrial-fishing/fusionpbx-install.sh.git
 
 #change the working directory
 cd /usr/src/fusionpbx-install.sh/debian

--- a/debian/pre-install.sh
+++ b/debian/pre-install.sh
@@ -7,7 +7,7 @@ apt-get update && apt-get upgrade -y
 apt-get install -y git lsb-release
 
 #get the install script
-cd /usr/src && git clone https://codeberg.org/industrial-fishing/fusionpbx-install.sh.git
+cd /usr/src && git clone https:/github.com/fusionpbx/fusionpbx-install.sh.git
 
 #change the working directory
 cd /usr/src/fusionpbx-install.sh/debian

--- a/debian/resources/config.sh
+++ b/debian/resources/config.sh
@@ -1,4 +1,3 @@
-
 # FusionPBX Settings
 domain_name=ip_address                      # hostname, ip_address or a custom value
 system_username=admin                       # default username admin
@@ -7,8 +6,8 @@ system_branch=5.4                           # master, 5.4
 
 # FreeSWITCH Settings
 switch_branch=stable                        # master, stable
-switch_source=true                          # true (source compile) or false (binary package)
-switch_package=false                        # true (binary package) or false (source compile)
+switch_source=false                          # true (source compile) or false (binary package)
+switch_package=true                        # true (binary package) or false (source compile)
 switch_version=1.10.12                      # which source code to download, only for source
 switch_tls=true                             # true or false
 switch_token=                               # Get the auth token from https://signalwire.com
@@ -34,6 +33,6 @@ letsencrypt_folder=true                     # true or false
 application_transcribe=true                # Speech to Text
 application_speech=true                    # Text to Speech
 application_device_logs=true               # Log device provision requests
-application_dialplan_tools=false           # Add additional dialplan applications
+application_dialplan_tools=true           # Add additional dialplan applications
 application_edit=false                     # Editor for XML, Provision, Scripts, and PHP
 application_sip_trunks=false               # Registration-based SIP trunks

--- a/debian/resources/config.sh
+++ b/debian/resources/config.sh
@@ -6,8 +6,8 @@ system_branch=5.4                           # master, 5.4
 
 # FreeSWITCH Settings
 switch_branch=stable                        # master, stable
-switch_source=false                          # true (source compile) or false (binary package)
-switch_package=true                        # true (binary package) or false (source compile)
+switch_source=true                          # true (source compile) or false (binary package)
+switch_package=false                        # true (binary package) or false (source compile)
 switch_version=1.10.12                      # which source code to download, only for source
 switch_tls=true                             # true or false
 switch_token=                               # Get the auth token from https://signalwire.com
@@ -33,6 +33,6 @@ letsencrypt_folder=true                     # true or false
 application_transcribe=true                # Speech to Text
 application_speech=true                    # Text to Speech
 application_device_logs=true               # Log device provision requests
-application_dialplan_tools=true           # Add additional dialplan applications
+application_dialplan_tools=false           # Add additional dialplan applications
 application_edit=false                     # Editor for XML, Provision, Scripts, and PHP
 application_sip_trunks=false               # Registration-based SIP trunks

--- a/debian/resources/environment.sh
+++ b/debian/resources/environment.sh
@@ -69,8 +69,7 @@ if [ .$cpu_architecture = .'arm' ]; then
 	if [ .$os_mode = .'32' ]; then
 		verbose "Correct CPU and Operating System detected, using the ARM repo"
 	elif [ .$os_mode = .'64' ]; then
-		switch_source=true
-		switch_package=false
+		verbose "Correct CPU and Operating System detected"
 	else
 		error "Unknown OS mode $os_mode this is unsupported"
 		switch_source=true

--- a/debian/resources/nginx.sh
+++ b/debian/resources/nginx.sh
@@ -58,6 +58,9 @@ fi
 if [ ."$php_version" = ."8.1" ]; then
         sed -i /etc/nginx/sites-available/fusionpbx -e 's#unix:.*;#unix:/var/run/php/php8.1-fpm.sock;#g'
 fi
+if [ ."$php_version" = ."8.2" ]; then
+        sed -i /etc/nginx/sites-available/fusionpbx -e 's#unix:.*;#unix:/var/run/php/php8.2-fpm.sock;#g'
+fi
 ln -s /etc/nginx/sites-available/fusionpbx /etc/nginx/sites-enabled/fusionpbx
 
 #self signed certificate

--- a/debian/resources/nginx.sh
+++ b/debian/resources/nginx.sh
@@ -33,6 +33,22 @@ if [ ."$os_codename" = ."jessie" ]; then
 	php_version=7.1
 fi
 
+if [ ."$cpu_architecture" = ."arm" ]; then
+	#Pi2 and Pi3 Raspbian, #Odroid
+	#if [ ."$os_codename" = ."stretch" ]; then
+	#      php_version=7.0
+	#fi
+	if [ ."$os_codename" = ."buster" ]; then
+	      php_version=7.3
+	fi
+	if [ ."$os_codename" = ."bullseye" ]; then
+	      php_version=7.4
+	fi
+	if [ ."$os_codename" = ."bookworm" ]; then
+	      php_version=8.2
+	fi
+fi
+
 #enable fusionpbx nginx config
 cp nginx/fusionpbx /etc/nginx/sites-available/fusionpbx
 

--- a/debian/resources/php.sh
+++ b/debian/resources/php.sh
@@ -34,75 +34,74 @@ elif [ ."$cpu_architecture" = ."arm" ]; then
 	if [ ."$os_codename" = ."bookworm" ]; then
 	      php_version=8.2
 	fi
-else
-	#11.x - bullseye
-	#10.x - buster
-	#9.x  - stretch
-	#8.x  - jessie
-	apt-get -y install apt-transport-https lsb-release ca-certificates
+fi
+#11.x - bullseye
+#10.x - buster
+#9.x  - stretch
+#8.x  - jessie
+apt-get -y install apt-transport-https lsb-release ca-certificates
 
-	#make sure keyrings directory exits
-	mkdir /etc/apt/keyrings
+#make sure keyrings directory exits
+mkdir /etc/apt/keyrings
 
-	if [ ."$os_codename" = ."jessie" ]; then
-		wget -O - https://packages.sury.org/php/apt.gpg | gpg --dearmor -o /etc/apt/keyrings/php.gpg
-		sh -c 'echo "deb [signed-by=/etc/apt/keyrings/php.gpg] https://packages.sury.org/php/ $(lsb_release -sc) main" > /etc/apt/sources.list.d/php.list'
+if [ ."$os_codename" = ."jessie" ]; then
+	wget -O - https://packages.sury.org/php/apt.gpg | gpg --dearmor -o /etc/apt/keyrings/php.gpg
+	sh -c 'echo "deb [signed-by=/etc/apt/keyrings/php.gpg] https://packages.sury.org/php/ $(lsb_release -sc) main" > /etc/apt/sources.list.d/php.list'
+fi
+if [ ."$os_codename" = ."stretch" ]; then
+	wget -O - https://packages.sury.org/php/apt.gpg | gpg --dearmor -o /etc/apt/keyrings/php.gpg
+	sh -c 'echo "deb [signed-by=/etc/apt/keyrings/php.gpg] https://packages.sury.org/php/ $(lsb_release -sc) main" > /etc/apt/sources.list.d/php.list'
+fi
+if [ ."$os_codename" = ."buster" ]; then
+	wget -O - https://packages.sury.org/php/apt.gpg | gpg --dearmor -o /etc/apt/keyrings/php.gpg
+	sh -c 'echo "deb [signed-by=/etc/apt/keyrings/php.gpg] https://packages.sury.org/php/ $(lsb_release -sc) main" > /etc/apt/sources.list.d/php.list'
+fi
+if [ ."$os_codename" = ."bullseye" ]; then
+	if [ ."$php_version" = ."8.1" ]; then
+		/usr/bin/apt -y install apt-transport-https lsb-release ca-certificates curl wget gnupg2
+		/usr/bin/wget -qO- https://packages.sury.org/php/apt.gpg | gpg --dearmor > /etc/apt/keyrings/sury-php-8.x.gpg
+		/usr/bin/sh -c 'echo "deb [signed-by=/etc/apt/keyrings/sury-php-8.x.gpg] https://packages.sury.org/php/ $(lsb_release -sc) main" > /etc/apt/sources.list.d/php.list'
 	fi
-	if [ ."$os_codename" = ."stretch" ]; then
-		wget -O - https://packages.sury.org/php/apt.gpg | gpg --dearmor -o /etc/apt/keyrings/php.gpg
-		sh -c 'echo "deb [signed-by=/etc/apt/keyrings/php.gpg] https://packages.sury.org/php/ $(lsb_release -sc) main" > /etc/apt/sources.list.d/php.list'
+	if [ ."$php_version" = ."8.2" ]; then
+		/usr/bin/apt -y install apt-transport-https lsb-release ca-certificates curl wget gnupg2
+		/usr/bin/wget -qO- https://packages.sury.org/php/apt.gpg | gpg --dearmor > /etc/apt/keyrings/sury-php-8.x.gpg
+		/usr/bin/sh -c 'echo "deb [signed-by=/etc/apt/keyrings/sury-php-8.x.gpg] https://packages.sury.org/php/ $(lsb_release -sc) main" > /etc/apt/sources.list.d/php.list'
 	fi
-	if [ ."$os_codename" = ."buster" ]; then
-		wget -O - https://packages.sury.org/php/apt.gpg | gpg --dearmor -o /etc/apt/keyrings/php.gpg
-		sh -c 'echo "deb [signed-by=/etc/apt/keyrings/php.gpg] https://packages.sury.org/php/ $(lsb_release -sc) main" > /etc/apt/sources.list.d/php.list'
+	if [ ."$php_version" = ."8.3" ]; then
+		/usr/bin/apt -y install apt-transport-https lsb-release ca-certificates curl wget gnupg2
+		/usr/bin/wget -qO- https://packages.sury.org/php/apt.gpg | gpg --dearmor > /etc/apt/keyrings/sury-php-8.x.gpg
+		/usr/bin/sh -c 'echo "deb [signed-by=/etc/apt/keyrings/sury-php-8.x.gpg] https://packages.sury.org/php/ $(lsb_release -sc) main" > /etc/apt/sources.list.d/php.list'
 	fi
-	if [ ."$os_codename" = ."bullseye" ]; then
-		if [ ."$php_version" = ."8.1" ]; then
-			/usr/bin/apt -y install apt-transport-https lsb-release ca-certificates curl wget gnupg2
-			/usr/bin/wget -qO- https://packages.sury.org/php/apt.gpg | gpg --dearmor > /etc/apt/keyrings/sury-php-8.x.gpg
-			/usr/bin/sh -c 'echo "deb [signed-by=/etc/apt/keyrings/sury-php-8.x.gpg] https://packages.sury.org/php/ $(lsb_release -sc) main" > /etc/apt/sources.list.d/php.list'
-		fi
-		if [ ."$php_version" = ."8.2" ]; then
-			/usr/bin/apt -y install apt-transport-https lsb-release ca-certificates curl wget gnupg2
-			/usr/bin/wget -qO- https://packages.sury.org/php/apt.gpg | gpg --dearmor > /etc/apt/keyrings/sury-php-8.x.gpg
-			/usr/bin/sh -c 'echo "deb [signed-by=/etc/apt/keyrings/sury-php-8.x.gpg] https://packages.sury.org/php/ $(lsb_release -sc) main" > /etc/apt/sources.list.d/php.list'
-		fi
-		if [ ."$php_version" = ."8.3" ]; then
-			/usr/bin/apt -y install apt-transport-https lsb-release ca-certificates curl wget gnupg2
-			/usr/bin/wget -qO- https://packages.sury.org/php/apt.gpg | gpg --dearmor > /etc/apt/keyrings/sury-php-8.x.gpg
-			/usr/bin/sh -c 'echo "deb [signed-by=/etc/apt/keyrings/sury-php-8.x.gpg] https://packages.sury.org/php/ $(lsb_release -sc) main" > /etc/apt/sources.list.d/php.list'
-		fi
-		if [ ."$php_version" = ."8.4" ]; then
-			/usr/bin/apt -y install apt-transport-https lsb-release ca-certificates curl wget gnupg2
-			/usr/bin/wget -qO- https://packages.sury.org/php/apt.gpg | gpg --dearmor > /etc/apt/keyrings/sury-php-8.x.gpg
-			/usr/bin/sh -c 'echo "deb [signed-by=/etc/apt/keyrings/sury-php-8.x.gpg] https://packages.sury.org/php/ $(lsb_release -sc) main" > /etc/apt/sources.list.d/php.list'
-		fi
+	if [ ."$php_version" = ."8.4" ]; then
+		/usr/bin/apt -y install apt-transport-https lsb-release ca-certificates curl wget gnupg2
+		/usr/bin/wget -qO- https://packages.sury.org/php/apt.gpg | gpg --dearmor > /etc/apt/keyrings/sury-php-8.x.gpg
+		/usr/bin/sh -c 'echo "deb [signed-by=/etc/apt/keyrings/sury-php-8.x.gpg] https://packages.sury.org/php/ $(lsb_release -sc) main" > /etc/apt/sources.list.d/php.list'
 	fi
- 	if [ ."$os_codename" = ."bookworm" ]; then
-		if [ ."$php_version" = ."8.1" ]; then
-			/usr/bin/apt -y install apt-transport-https lsb-release ca-certificates curl wget gnupg2
-			/usr/bin/wget -qO- https://packages.sury.org/php/apt.gpg | gpg --dearmor > /etc/apt/keyrings/sury-php-8.x.gpg
-   			/usr/bin/chmod 644 /etc/apt/keyrings/sury-php-8.x.gpg
-			/usr/bin/sh -c 'echo "deb [signed-by=/etc/apt/keyrings/sury-php-8.x.gpg] https://packages.sury.org/php/ $(lsb_release -sc) main" > /etc/apt/sources.list.d/php.list'
-		fi
-		if [ ."$php_version" = ."8.2" ]; then
-			/usr/bin/apt -y install apt-transport-https lsb-release ca-certificates curl wget gnupg2
-			/usr/bin/wget -qO- https://packages.sury.org/php/apt.gpg | gpg --dearmor > /etc/apt/keyrings/sury-php-8.x.gpg
-   			/usr/bin/chmod 644 /etc/apt/keyrings/sury-php-8.x.gpg
-			/usr/bin/sh -c 'echo "deb [signed-by=/etc/apt/keyrings/sury-php-8.x.gpg] https://packages.sury.org/php/ $(lsb_release -sc) main" > /etc/apt/sources.list.d/php.list'
-		fi
-		if [ ."$php_version" = ."8.3" ]; then
-			/usr/bin/apt -y install apt-transport-https lsb-release ca-certificates curl wget gnupg2
-			/usr/bin/wget -qO- https://packages.sury.org/php/apt.gpg | gpg --dearmor > /etc/apt/keyrings/sury-php-8.x.gpg
-   			/usr/bin/chmod 644 /etc/apt/keyrings/sury-php-8.x.gpg
-			/usr/bin/sh -c 'echo "deb [signed-by=/etc/apt/keyrings/sury-php-8.x.gpg] https://packages.sury.org/php/ $(lsb_release -sc) main" > /etc/apt/sources.list.d/php.list'
-		fi
-		if [ ."$php_version" = ."8.4" ]; then
-			/usr/bin/apt -y install apt-transport-https lsb-release ca-certificates curl wget gnupg2
-			/usr/bin/wget -qO- https://packages.sury.org/php/apt.gpg | gpg --dearmor > /etc/apt/keyrings/sury-php-8.x.gpg
-   			/usr/bin/chmod 644 /etc/apt/keyrings/sury-php-8.x.gpg
-			/usr/bin/sh -c 'echo "deb [signed-by=/etc/apt/keyrings/sury-php-8.x.gpg] https://packages.sury.org/php/ $(lsb_release -sc) main" > /etc/apt/sources.list.d/php.list'
-		fi
+fi
+if [ ."$os_codename" = ."bookworm" ]; then
+	if [ ."$php_version" = ."8.1" ]; then
+		/usr/bin/apt -y install apt-transport-https lsb-release ca-certificates curl wget gnupg2
+		/usr/bin/wget -qO- https://packages.sury.org/php/apt.gpg | gpg --dearmor > /etc/apt/keyrings/sury-php-8.x.gpg
+		/usr/bin/chmod 644 /etc/apt/keyrings/sury-php-8.x.gpg
+		/usr/bin/sh -c 'echo "deb [signed-by=/etc/apt/keyrings/sury-php-8.x.gpg] https://packages.sury.org/php/ $(lsb_release -sc) main" > /etc/apt/sources.list.d/php.list'
+	fi
+	if [ ."$php_version" = ."8.2" ]; then
+		/usr/bin/apt -y install apt-transport-https lsb-release ca-certificates curl wget gnupg2
+		/usr/bin/wget -qO- https://packages.sury.org/php/apt.gpg | gpg --dearmor > /etc/apt/keyrings/sury-php-8.x.gpg
+		/usr/bin/chmod 644 /etc/apt/keyrings/sury-php-8.x.gpg
+		/usr/bin/sh -c 'echo "deb [signed-by=/etc/apt/keyrings/sury-php-8.x.gpg] https://packages.sury.org/php/ $(lsb_release -sc) main" > /etc/apt/sources.list.d/php.list'
+	fi
+	if [ ."$php_version" = ."8.3" ]; then
+		/usr/bin/apt -y install apt-transport-https lsb-release ca-certificates curl wget gnupg2
+		/usr/bin/wget -qO- https://packages.sury.org/php/apt.gpg | gpg --dearmor > /etc/apt/keyrings/sury-php-8.x.gpg
+		/usr/bin/chmod 644 /etc/apt/keyrings/sury-php-8.x.gpg
+		/usr/bin/sh -c 'echo "deb [signed-by=/etc/apt/keyrings/sury-php-8.x.gpg] https://packages.sury.org/php/ $(lsb_release -sc) main" > /etc/apt/sources.list.d/php.list'
+	fi
+	if [ ."$php_version" = ."8.4" ]; then
+		/usr/bin/apt -y install apt-transport-https lsb-release ca-certificates curl wget gnupg2
+		/usr/bin/wget -qO- https://packages.sury.org/php/apt.gpg | gpg --dearmor > /etc/apt/keyrings/sury-php-8.x.gpg
+		/usr/bin/chmod 644 /etc/apt/keyrings/sury-php-8.x.gpg
+		/usr/bin/sh -c 'echo "deb [signed-by=/etc/apt/keyrings/sury-php-8.x.gpg] https://packages.sury.org/php/ $(lsb_release -sc) main" > /etc/apt/sources.list.d/php.list'
 	fi
 fi
 apt-get update -y

--- a/debian/resources/sngrep.sh
+++ b/debian/resources/sngrep.sh
@@ -9,19 +9,11 @@ cd "$(dirname "$0")"
 . ./environment.sh
 
 #add sngrep
-if [ ."$cpu_architecture" = ."arm" ]; then
-	#source install
-	apt-get install -y git autoconf automake gcc make libncurses5-dev libpcap-dev libssl-dev libpcre3-dev
-	cd /usr/src && git clone https://github.com/irontec/sngrep
-	cd /usr/src/sngrep && ./bootstrap.sh
-	cd /usr/src/sngrep && ./configure
-	cd /usr/src/sngrep && make install
-else
-	#package install
-	if [ ."$os_codename" = ."jessie" ]; then
-		echo "deb http://packages.irontec.com/debian $os_codename main" > /etc/apt/sources.list.d/sngrep.list
-		wget http://packages.irontec.com/public.key -q -O - | apt-key add -
-  		apt-get update
-	fi
-	apt-get install -y sngrep
+
+#package install
+if [ ."$os_codename" = ."jessie" ]; then
+	echo "deb http://packages.irontec.com/debian $os_codename main" > /etc/apt/sources.list.d/sngrep.list
+	wget http://packages.irontec.com/public.key -q -O - | apt-key add -
+	apt-get update
 fi
+apt-get install -y sngrep

--- a/debian/resources/switch/package-all.sh
+++ b/debian/resources/switch/package-all.sh
@@ -11,16 +11,12 @@ cd "$(dirname "$0")"
 apt-get update && apt-get install -y ntp curl memcached haveged apt-transport-https
 apt-get update && apt-get install -y wget lsb-release gnupg2
 
-if [ ."$cpu_architecture" = ."x86" ]; then
+if [ ."$cpu_architecture" = ."x86" ] || [ ."$cpu_architecture" = ."arm" ]; then
 	wget -O - https://files.freeswitch.org/repo/deb/debian-release/fsstretch-archive-keyring.asc | apt-key add -
 	echo "deb http://files.freeswitch.org/repo/deb/debian-release/ `lsb_release -sc` main" > /etc/apt/sources.list.d/freeswitch.list
 	echo "deb-src http://files.freeswitch.org/repo/deb/debian-release/ `lsb_release -sc` main" >> /etc/apt/sources.list.d/freeswitch.list
 fi
-if [ ."$cpu_architecture" = ."arm" ]; then
-	wget -O - https://files.freeswitch.org/repo/deb/rpi/debian-release/freeswitch_archive_g0.pub | apt-key add -
-	echo "deb http://files.freeswitch.org/repo/deb/rpi/debian-release/ `lsb_release -sc` main" > /etc/apt/sources.list.d/freeswitch.list
-	echo "deb-src http://files.freeswitch.org/repo/deb/rpi/debian-release/ `lsb_release -sc` main" >> /etc/apt/sources.list.d/freeswitch.list
-fi
+
 apt-get update && apt-get install -y freeswitch-meta-all freeswitch-all-dbg gdb
 
 #make sure that postgresql is started before starting freeswitch

--- a/debian/resources/switch/package-release.sh
+++ b/debian/resources/switch/package-release.sh
@@ -12,17 +12,11 @@ apt-get update && apt-get install -y curl memcached haveged apt-transport-https
 apt-get update && apt-get install -y gnupg gnupg2
 apt-get update && apt-get install -y wget lsb-release sox
 
-if [ ."$cpu_architecture" = ."x86" ]; then
+if [ ."$cpu_architecture" = ."x86" ] || [ ."$cpu_architecture" = ."arm" ]; then
 	wget --http-user=signalwire --http-password=$switch_token -O /usr/share/keyrings/signalwire-freeswitch-repo.gpg https://freeswitch.signalwire.com/repo/deb/debian-release/signalwire-freeswitch-repo.gpg
 	echo "machine freeswitch.signalwire.com login signalwire password $switch_token" > /etc/apt/auth.conf
 	echo "deb [signed-by=/usr/share/keyrings/signalwire-freeswitch-repo.gpg] https://freeswitch.signalwire.com/repo/deb/debian-release/ `lsb_release -sc` main" > /etc/apt/sources.list.d/freeswitch.list
 	echo "deb-src [signed-by=/usr/share/keyrings/signalwire-freeswitch-repo.gpg] https://freeswitch.signalwire.com/repo/deb/debian-release/ `lsb_release -sc` main" >> /etc/apt/sources.list.d/freeswitch.list
-fi
-if [ ."$cpu_architecture" = ."arm" ]; then
-	wget --http-user=signalwire --http-password=$switch_token -O /usr/share/keyrings/signalwire-freeswitch-repo.gpg https://freeswitch.signalwire.com/repo/deb/rpi/debian-release/freeswitch_archive_g0.pub
-	echo "machine freeswitch.signalwire.com login signalwire password $switch_token" > /etc/apt/auth.conf
-	echo "deb [signed-by=/etc/apt/keyrings/signalwire-freeswitch-repo.gpg] https://freeswitch.signalwire.com/repo/deb/rpi/debian-release/ `lsb_release -sc` main" > /etc/apt/sources.list.d/freeswitch.list
-	echo "deb-src [signed-by=/etc/apt/keyrings/signalwire-freeswitch-repo.gpg] https://freeswitch.signalwire.com/repo/deb/rpi/debian-release/ `lsb_release -sc` main" >> /etc/apt/sources.list.d/freeswitch.list
 fi
 
 apt-get update

--- a/debian/resources/switch/repo.sh
+++ b/debian/resources/switch/repo.sh
@@ -12,14 +12,9 @@ apt-get update && apt-get install -y curl memcached haveged apt-transport-https
 apt-get update && apt-get install -y gnupg gnupg2
 apt-get update && apt-get install -y wget lsb-release
 
-if [ ."$cpu_architecture" = ."x86" ]; then
+if [ ."$cpu_architecture" = ."x86" ] || [ ."$cpu_architecture" = ."arm" ]; then
 	wget --http-user=signalwire --http-password=$switch_token -O /usr/share/keyrings/signalwire-freeswitch-repo.gpg https://freeswitch.signalwire.com/repo/deb/debian-release/signalwire-freeswitch-repo.gpg
 	echo "machine freeswitch.signalwire.com login signalwire password $switch_token" > /etc/apt/auth.conf
 	echo "deb [signed-by=/usr/share/keyrings/signalwire-freeswitch-repo.gpg] https://freeswitch.signalwire.com/repo/deb/debian-release/ `lsb_release -sc` main" > /etc/apt/sources.list.d/freeswitch.list
 	echo "deb-src [signed-by=/usr/share/keyrings/signalwire-freeswitch-repo.gpg] https://freeswitch.signalwire.com/repo/deb/debian-release/ `lsb_release -sc` main" >> /etc/apt/sources.list.d/freeswitch.list
-fi
-if [ ."$cpu_architecture" = ."arm" ]; then
-	wget --http-user=signalwire --http-password=$switch_token -O /usr/share/keyrings/signalwire-freeswitch-repo.gpg https://files.freeswitch.org/repo/deb/rpi/debian-release/freeswitch_archive_g0.pub
-	echo "deb [signed-by=/usr/share/keyrings/signalwire-freeswitch-repo.gpg] http://files.freeswitch.org/repo/deb/rpi/debian-release/ `lsb_release -sc` main" > /etc/apt/sources.list.d/freeswitch.list
-	echo "deb-src [signed-by=/usr/share/keyrings/signalwire-freeswitch-repo.gpg] http://files.freeswitch.org/repo/deb/rpi/debian-release/ `lsb_release -sc` main" >> /etc/apt/sources.list.d/freeswitch.list
 fi


### PR DESCRIPTION
I've modified the install script to allow package install for arm64.

- remove fallback to source install when architecture is arm64
- update freeswitch repository sources. The main repo contains arm64 packages these days
- fix php version mismatch. (8.2 vs 8.1). On arm64 php 8.2 is selected in `php.sh`, added the same logic to `nginx.sh` and added php8.2 option for nginx
- fix php install for arm architectures. The if statement bypassed the php install entirely when architecture was not x86
- enable sngrep package install for arm

The changes in this PR were tested on a raspberry pi 4. 

Let me know if there is any changes you disagree with. 