### PR TITLE
Fix PHP FPM Service Name

### DIFF
--- a/freebsd/resources/php.sh
+++ b/freebsd/resources/php.sh
@@ -44,5 +44,5 @@ sed -i' ' -e s:'post_max_size = .*:post_max_size = 80M:g' /usr/local/etc/php.ini
 sed -i' ' -e s:'upload_max_filesize = .*:upload_max_filesize = 80M:g' /usr/local/etc/php.ini
 sed -i' ' -e s:'; max_input_vars = .*:max_input_vars = 8000:g' /usr/local/etc/php.ini
 
-#restart php-fpm
-service php-fpm restart
+#restart php_fpm
+service php_fpm restart


### PR DESCRIPTION
The service name is `php_fpm` not `php-fpm`:

```
Configuring PHP
php-fpm does not exist in /etc/rc.d or the local startup
directories (/usr/local/etc/rc.d), or is not executable
```

```
service php_fpm restart
Performing sanity check on php_fpm configuration:
[26-Jul-2025 18:22:16] NOTICE: configuration file /usr/local/etc/php-fpm.conf test is successful
```