### PR TITLE
Don't pin ghostscript10 version to10.02.1

### DIFF
--- a/freebsd/resources/switch/package-release.sh
+++ b/freebsd/resources/switch/package-release.sh
@@ -7,7 +7,7 @@ cd "$(dirname "$0")"
 . ../config.sh
 
 #install dependencies
-pkg install --yes tiff ghostscript10-10.02.1 memcached sox
+pkg install --yes tiff ghostscript10 memcached sox
 
 #set the current working directory
 cwd=$(pwd)


### PR DESCRIPTION
This is pinned to a specific version `10.02.1`, which as of 2025-07-26 isn't avaialble anymore.  Unless there is a reason to do so, I think we should use whatever version is currently available: 

```
pkg: No packages available to install matching 'ghostscript10-10.02.1' have been found in the repositories
```

According to [Freshports](https://www.freshports.org/print/ghostscript10/), ghostscript10 is still in the ports tree, but the version number has been updated:

```
root@pbx:~ # pkg install ghostscript10
Updating FreeBSD repository catalogue...
FreeBSD repository is up to date.
Updating FreeBSD-kmods repository catalogue...
FreeBSD-kmods repository is up to date.
All repositories are up to date.
The following 18 package(s) will be affected (of 0 checked):

New packages to be INSTALLED:
        avahi-app: 0.8_6 [FreeBSD]
        cups: 2.4.11_1 [FreeBSD]
        dbus-glib: 0.114 [FreeBSD]
        gdbm: 1.25 [FreeBSD]
        ghostscript10: 10.05.1 [FreeBSD]
        gnome_subr: 1.0 [FreeBSD]
        jbig2dec: 0.20_1 [FreeBSD]
        lcms2: 2.17 [FreeBSD]
        libXt: 1.3.0,1 [FreeBSD]
        libdaemon: 0.14_1 [FreeBSD]
        libevent: 2.1.12 [FreeBSD]
        libfontenc: 1.1.8 [FreeBSD]
        libidn: 1.43 [FreeBSD]
        libpaper: 1.1.28_1 [FreeBSD]
        mkfontscale: 1.2.3 [FreeBSD]
        openjpeg: 2.5.3 [FreeBSD]
        poppler-data: 0.4.12 [FreeBSD]
        urw-base35-fonts: 20200910 [FreeBSD]

Number of packages to be installed: 18

The process will require 84 MiB more space.
25 MiB to be downloaded.

Proceed with this action? [y/N]: y
[1/18] Fetching libXt-1.3.0,1.pkg: 100%  476 KiB 487.3kB/s    00:01
[2/18] Fetching cups-2.4.11_1.pkg: 100%    2 MiB 412.6kB/s    00:04
[3/18] Fetching lcms2-2.17.pkg: 100%    2 MiB 759.8kB/s    00:03
[4/18] Fetching mkfontscale-1.2.3.pkg: 100%   22 KiB  22.5kB/s    00:01
[5/18] Fetching openjpeg-2.5.3.pkg: 100%  334 KiB 341.8kB/s    00:01
[6/18] Fetching libidn-1.43.pkg: 100%  281 KiB 287.6kB/s    00:01
[7/18] Fetching gnome_subr-1.0.pkg: 100%    2 KiB   1.9kB/s    00:01
[8/18] Fetching libpaper-1.1.28_1.pkg: 100%   25 KiB  25.9kB/s    00:01
[9/18] Fetching urw-base35-fonts-20200910.pkg: 100%    8 MiB 439.0kB/s    00:20
[10/18] Fetching libevent-2.1.12.pkg: 100%  346 KiB 353.9kB/s    00:01
[11/18] Fetching gdbm-1.25.pkg: 100%  251 KiB 256.7kB/s    00:01
[12/18] Fetching avahi-app-0.8_6.pkg: 100%  374 KiB 382.8kB/s    00:01
[13/18] Fetching ghostscript10-10.05.1.pkg: 100%    9 MiB 670.5kB/s    00:14
[14/18] Fetching libfontenc-1.1.8.pkg: 100%   21 KiB  21.7kB/s    00:01
[15/18] Fetching dbus-glib-0.114.pkg: 100%  175 KiB 178.8kB/s    00:01
[16/18] Fetching jbig2dec-0.20_1.pkg: 100%   94 KiB  96.4kB/s    00:01
[17/18] Fetching libdaemon-0.14_1.pkg: 100%   35 KiB  36.0kB/s    00:01
[18/18] Fetching poppler-data-0.4.12.pkg: 100%    2 MiB 686.4kB/s    00:03
Checking integrity... done (0 conflicting)
[1/18] Installing dbus-glib-0.114...
[1/18] Extracting dbus-glib-0.114: 100%
[2/18] Installing gdbm-1.25...
[2/18] Extracting gdbm-1.25: 100%
[3/18] Installing gnome_subr-1.0...
[3/18] Extracting gnome_subr-1.0: 100%
[4/18] Installing jbig2dec-0.20_1...
[4/18] Extracting jbig2dec-0.20_1: 100%
[5/18] Installing lcms2-2.17...
[5/18] Extracting lcms2-2.17: 100%
[6/18] Installing libXt-1.3.0,1...
[6/18] Extracting libXt-1.3.0,1: 100%
[7/18] Installing libdaemon-0.14_1...
[7/18] Extracting libdaemon-0.14_1: 100%
[8/18] Installing libevent-2.1.12...
[8/18] Extracting libevent-2.1.12: 100%
[9/18] Installing avahi-app-0.8_6...
===> Creating groups
Creating group 'avahi' with gid '558'
===> Creating users
Creating user 'avahi' with uid '558'
[9/18] Extracting avahi-app-0.8_6: 100%
[10/18] Installing libfontenc-1.1.8...
[10/18] Extracting libfontenc-1.1.8: 100%
[11/18] Installing libidn-1.43...
[11/18] Extracting libidn-1.43: 100%
[12/18] Installing libpaper-1.1.28_1...
[12/18] Extracting libpaper-1.1.28_1: 100%
[13/18] Installing cups-2.4.11_1...
===> Creating groups
Creating group 'cups' with gid '193'
===> Creating users
Creating user 'cups' with uid '193'
[13/18] Extracting cups-2.4.11_1: 100%
[14/18] Installing mkfontscale-1.2.3...
[14/18] Extracting mkfontscale-1.2.3: 100%
[15/18] Installing openjpeg-2.5.3...
[15/18] Extracting openjpeg-2.5.3: 100%
[16/18] Installing poppler-data-0.4.12...
[16/18] Extracting poppler-data-0.4.12: 100%
[17/18] Installing urw-base35-fonts-20200910...
[17/18] Extracting urw-base35-fonts-20200910: 100%
[18/18] Installing ghostscript10-10.05.1...
[18/18] Extracting ghostscript10-10.05.1: 100%
=====
Message from ghostscript10-10.05.1:

--
This package installs a script named dvipdf that depends on dvips.  If you
want to use this script you need to install print/tex-dvipsk.
```

Unfortunately it does pull in tons of extra stuff.