### PR TITLE
Fix: adding -y to apt installation of cron

### DIFF
--- a/debian/resources/finish.sh
+++ b/debian/resources/finish.sh
@@ -106,7 +106,7 @@ chown -R www-data:www-data /var/run/fusionpbx
 cd /var/www/fusionpbx && /usr/bin/php /var/www/fusionpbx/core/upgrade/upgrade.php --services
 
 #install crontab
-apt install cron
+apt install -y cron
 
 #welcome message
 echo ""

--- a/devuan/resources/finish.sh
+++ b/devuan/resources/finish.sh
@@ -109,7 +109,7 @@ cd /var/www/fusionpbx && /usr/bin/php /var/www/fusionpbx/core/upgrade/upgrade.ph
 cd /var/www/fusionpbx && /usr/bin/php /var/www/fusionpbx/core/upgrade/upgrade.php --services
 
 #add xml cdr import to crontab
-#apt install cron
+#apt install -y cron
 #cat <(crontab -l) <(echo "* * * * * $(which php) /var/www/fusionpbx/app/xml_cdr/xml_cdr_import.php 300") | crontab -
 
 #welcome message

--- a/ubuntu/resources/finish.sh
+++ b/ubuntu/resources/finish.sh
@@ -105,7 +105,7 @@ chown -R www-data:www-data /var/run/fusionpbx
 cd /var/www/fusionpbx && /usr/bin/php /var/www/fusionpbx/core/upgrade/upgrade.php --services
 
 #install crontab
-apt install cron
+apt install -y cron
 
 #welcome message
 echo ""


### PR DESCRIPTION
Near the end of the finish.sh script for Debian and Ubuntu, was "apt install cron". This was missing -y switch which breaks unattended installations for these distros.